### PR TITLE
Bump pytest from 7.4.0 to 7.4.1 (#135)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1315,13 +1315,13 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.4.0"
+version = "7.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
-    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+    {file = "pytest-7.4.1-py3-none-any.whl", hash = "sha256:460c9a59b14e27c602eb5ece2e47bec99dc5fc5f6513cf924a7d03a578991b1f"},
+    {file = "pytest-7.4.1.tar.gz", hash = "sha256:2f2301e797521b23e4d2585a0a3d7b5e50fdddaaf7e7d6773ea26ddb17c213ab"},
 ]
 
 [package.dependencies]
@@ -1789,4 +1789,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "0c5b80d18564d3b5132ccf36a65f0bf45d9fe9ac81d7183ae7b07b86007810b6"
+content-hash = "fcced6c2706c357fae967e91cbd153d0f15ec1a7ce28953d141bb9ee569e2e79"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ cvxpy = "*"
 fire = "*"
 
 [tool.poetry.group.test.dependencies]
-pytest = "7.4.0"
+pytest = "7.4.1"
 pytest-cov = "4.1.0"
 mock = "*"
 


### PR DESCRIPTION
* Bump pytest from 7.4.0 to 7.4.1

Bumps [pytest](https://github.com/pytest-dev/pytest) from 7.4.0 to 7.4.1.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/7.4.0...7.4.1)

---
updated-dependencies:
- dependency-name: pytest dependency-type: direct:development update-type: version-update:semver-patch ...



* fmt lock file

---------