### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for cvxmarkowitz

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for cvxmarkowitz.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs cvxmarkowitz and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies so PyInstaller can discover
+# and bundle cvxmarkowitz into each frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover numpy's C-extension submodules on its own, so
+# the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# numpy submodule. cvxmarkowitz.types imports cvxpy (which pulls scipy), so
+# scipy and cvxpy are collected too.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all scipy --collect-all cvxpy
+done

--- a/tests/fuzz/fuzz_fill.py
+++ b/tests/fuzz/fuzz_fill.py
@@ -1,0 +1,60 @@
+"""Fuzz the cvxmarkowitz padding helpers against arbitrary shapes.
+
+``fill_vector`` and ``fill_matrix`` pad an input array into a larger zero array
+of a target shape. They must never crash with an unexpected exception on
+adversarial input — mismatched/negative target shapes should raise a clean
+error (ValueError/IndexError), not blow up unexpectedly. This harness exercises
+that contract with coverage-guided input.
+
+Run locally:
+    pip install atheris numpy
+    python tests/fuzz/fuzz_fill.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the native dependencies OUTSIDE the instrumentation block so they
+# load uninstrumented; only the first-party package under test is instrumented.
+# cvxmarkowitz.types imports cvxpy (which pulls scipy), so those are pre-imported
+# too even though the fill helpers themselves only use numpy.
+import cvxpy  # noqa: F401  # pre-imported uninstrumented
+import numpy as np
+import scipy.sparse  # noqa: F401  # pre-imported uninstrumented
+
+with atheris.instrument_imports():
+    from cvxmarkowitz.utils.fill import fill_matrix, fill_vector
+
+_ALLOWED = (ValueError, IndexError, TypeError)
+
+
+def test_one_input(data: bytes) -> None:
+    """Pad fuzzed vectors/matrices to fuzzed target shapes."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    n = fdp.ConsumeIntInRange(0, 8)
+    vec = np.array([fdp.ConsumeFloat() for _ in range(n)], dtype=np.float64)
+    with contextlib.suppress(_ALLOWED):
+        fill_vector(vec, fdp.ConsumeIntInRange(0, 12))
+
+    r = fdp.ConsumeIntInRange(0, 6)
+    c = fdp.ConsumeIntInRange(0, 6)
+    mat = np.array([fdp.ConsumeFloat() for _ in range(r * c)], dtype=np.float64).reshape(r, c)
+    with contextlib.suppress(_ALLOWED):
+        fill_matrix(mat, fdp.ConsumeIntInRange(0, 8), fdp.ConsumeIntInRange(0, 8))
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Opt-in **ClusterFuzzLite** scaffold so the existing `rhiza_fuzzing.yml` runs.
- `.clusterfuzzlite/Dockerfile` + `build.sh` (`--collect-all numpy/scipy/cvxpy` — `cvxmarkowitz.types` imports cvxpy)
- `tests/fuzz/fuzz_fill.py` — fuzzes `fill_vector`/`fill_matrix` with arbitrary shapes

## Test plan
- [x] Built **and run** against the OSS-Fuzz `base-builder-python` image — 2000 runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
