### PR TITLE
Bump pyproject version to 0.0.1 to match latest git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cvxmarkowitz"
-version = "0.0.0"
+version = "0.0.1"
 description = "Markowitz"
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"},
     {name = "Kasper Johansson"},

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "cvxmarkowitz"
-version = "0.0.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "clarabel" },


### PR DESCRIPTION
Closes #514

## What changed
- `pyproject.toml`: `[project].version` 0.0.0 -> 0.0.1 to match the latest released git tag `v0.0.1`.
- `uv.lock`: refreshed by the `uv-lock` pre-commit hook (`cvxmarkowitz v0.0.0 -> v0.0.1`).

## Why
The Rhiza structure test `TestGitTagVersion::test_latest_tag_matches_pyproject_version` requires the static `[project].version` to equal the latest `vX.Y.Z` git tag. The mismatch made `make validate` fail on `main`.

## Confirming gate
`make validate` now passes (139 passed). `make fmt` clean.