### PR TITLE
chore: update rhiza to v1.0.1

### DIFF
--- a/.claude/commands/rhiza_quality.md
+++ b/.claude/commands/rhiza_quality.md
@@ -80,8 +80,19 @@ the specific file(s)/lines or config to change, and a crisp acceptance criterion
 ("done when…"). Keep them in-scope (locally-owned, per the scoping rule above) —
 flag anything Rhiza-owned as upstream rather than listing it as a local action.
 Order them by leverage (biggest score gain for least effort first). This is a
-list of recommendations only — do not create GitHub issues or change code unless
-I explicitly ask.
+list of recommendations only — do not change code unless I explicitly ask.
+
+Then offer to file the findings as issues — using a menu, not a free-text prompt.
+Present the actionable findings as a multi-select menu (the AskUserQuestion tool
+with `multiSelect: true`), one option per finding labelled by its title, so I can
+pick exactly which ones to file — including none. Create nothing without an
+explicit selection. For each finding I select, detect the hosting platform from
+the git remote (`git remote get-url origin`) and create one issue with the
+matching CLI — GitHub → `gh issue create`, GitLab → `glab issue create` (skip and
+say so if the relevant CLI is unavailable or unauthenticated). Make each issue
+self-contained: title from the finding, and a body carrying the subcategory, the
+current→target score, the specific file(s)/lines or config to change, and the
+"done when…" acceptance criterion. Report back the created issue URLs.
 
 If everything passes, say so plainly — but still produce the 1–10 subcategory
 marks. Do not fix anything unless I ask — this command only assesses.

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.1
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.1
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.1
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.1
     secrets: inherit

--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -37,7 +37,9 @@ install: pre-install install-uv ## install
 	  printf "${BLUE}[INFO] Using existing virtual environment at ${VENV}, skipping creation${RESET}\n"; \
 	fi
 
-	# Install the dependencies from pyproject.toml (if it exists)
+	# Install the dependencies from pyproject.toml (if it exists).
+	# --inexact keeps dev tools from .rhiza/requirements/*.txt (installed below) instead of pruning them each run,
+	# so repeated 'make' targets no longer uninstall and reinstall the whole tool set on every invocation.
 	@if [ -f "pyproject.toml" ]; then \
 	  if [ -f "uv.lock" ]; then \
 	    if ! ${UV_BIN} lock --check >/dev/null 2>&1; then \
@@ -47,10 +49,10 @@ install: pre-install install-uv ## install
 	      exit 1; \
 	    fi; \
 	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  else \
 	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
 	  fi; \
 	else \
 	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 04d8f42656366a9e07dc584ff75ab579764d89b0
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.1
 include: []
 exclude: []
 templates:
@@ -71,6 +71,7 @@ files:
 - .rhiza/tests/api/test_make_variable_overrides.py
 - .rhiza/tests/api/test_makefile_api.py
 - .rhiza/tests/api/test_makefile_targets.py
+- .rhiza/tests/api/test_releasing_targets.py
 - .rhiza/tests/conftest.py
 - .rhiza/tests/integration/test_book_targets.py
 - .rhiza/tests/integration/test_docs_targets.py
@@ -107,5 +108,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T18:08:13Z'
+synced_at: '2026-07-03T15:47:43Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: jebel-quant/rhiza
-template-branch: "v0.19.9"
+template-branch: "v1.0.1"
 
 profiles:
   - github-project

--- a/.rhiza/tests/README.md
+++ b/.rhiza/tests/README.md
@@ -129,8 +129,11 @@ uv run pytest .rhiza/tests/ --cov
 - `git_repo` — Sandboxed git repository (function-scoped)
 
 ### Category-specific fixtures
-- `api/conftest.py` — `setup_tmp_makefile`, `run_make`, `setup_rhiza_git_repo`
+- `api/conftest.py` — `setup_tmp_makefile` fixture (and the `SPLIT_MAKEFILES` constant)
 - `sync/conftest.py` — `setup_sync_env`
+
+Shared helpers (`run_make`, `setup_rhiza_git_repo`, `strip_ansi`) are imported
+directly from `test_utils` — see [Import Patterns](#import-patterns) below.
 
 ## Writing Tests
 

--- a/.rhiza/tests/api/conftest.py
+++ b/.rhiza/tests/api/conftest.py
@@ -2,9 +2,10 @@
 
 This conftest provides:
 - setup_tmp_makefile: Copies Makefile and split files to temp dir for isolated testing
-- run_make: Helper to execute make commands with dry-run support (imported from test_utils)
-- setup_rhiza_git_repo: Initialize a git repo configured as rhiza origin (imported from test_utils)
 - SPLIT_MAKEFILES: List of split Makefile paths
+
+Shared helpers (run_make, setup_rhiza_git_repo, strip_ansi) live in test_utils;
+import them from there directly rather than via this module.
 
 Security Notes:
 - S101 (assert usage): Asserts are used in pytest tests to validate conditions
@@ -17,16 +18,9 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
-
-tests_root = Path(__file__).resolve().parents[1]
-if str(tests_root) not in sys.path:
-    sys.path.insert(0, str(tests_root))
-
-from test_utils import run_make, setup_rhiza_git_repo, strip_ansi  # noqa: E402, F401
 
 # Split Makefile paths that are included in the main Makefile
 # These are now located in .rhiza/make.d/ directory

--- a/.rhiza/tests/api/test_github_targets.py
+++ b/.rhiza/tests/api/test_github_targets.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import pytest
 
-# Import run_make from local conftest (setup_tmp_makefile is autouse)
-from api.conftest import run_make
+# setup_tmp_makefile (autouse) comes from the api/ conftest; run_make is a shared
+# helper imported directly from test_utils.
+from test_utils import run_make
 
 # Every GitHub helper target defined in github.mk; all must appear in `make help`.
 _GH_TARGETS = (

--- a/.rhiza/tests/api/test_make_variable_overrides.py
+++ b/.rhiza/tests/api/test_make_variable_overrides.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 
-from api.conftest import run_make, strip_ansi
+from test_utils import run_make, strip_ansi
 
 
 class TestCoverageFailUnder:

--- a/.rhiza/tests/api/test_makefile_api.py
+++ b/.rhiza/tests/api/test_makefile_api.py
@@ -90,8 +90,8 @@ def setup_api_env(logger, root, tmp_path: Path):
         os.chdir(old_cwd)
 
 
-# Import run_make from local conftest
-from api.conftest import run_make  # noqa: E402
+# Imported after the module-level fixture above (hence the E402 exemption).
+from test_utils import run_make  # noqa: E402
 
 
 def test_api_delegation(logger, setup_api_env):

--- a/.rhiza/tests/api/test_makefile_targets.py
+++ b/.rhiza/tests/api/test_makefile_targets.py
@@ -17,7 +17,8 @@ import re
 from pathlib import Path
 
 import pytest
-from api.conftest import SPLIT_MAKEFILES, run_make, setup_rhiza_git_repo, strip_ansi
+from api.conftest import SPLIT_MAKEFILES
+from test_utils import run_make, setup_rhiza_git_repo, strip_ansi
 
 
 def assert_uvx_command_uses_version(output: str, tmp_path, command_fragment: str):

--- a/.rhiza/tests/api/test_releasing_targets.py
+++ b/.rhiza/tests/api/test_releasing_targets.py
@@ -1,0 +1,66 @@
+"""Tests for the releasing/versioning Makefile targets using safe dry-runs.
+
+This file and its associated tests flow down via a SYNC action from the
+jebel-quant/rhiza repository (https://github.com/jebel-quant/rhiza).
+
+The release targets live in .rhiza/make.d/releasing.mk. These tests validate
+that `changelog` and `release-status` resolve and emit the expected commands
+without executing them, by invoking `make -n` (dry-run) via the shared
+`run_make` helper. The autouse `setup_tmp_makefile` fixture copies releasing.mk
+(and github.mk, which defines FORGE_TYPE) into an isolated temp dir.
+
+The GitHub branch of `release-status` recurses via $(MAKE) and pipes to a
+pager, both of which GNU make runs even under -n, so its recipe shape is
+asserted by reading the source file rather than by dry-running it.
+"""
+
+from __future__ import annotations
+
+from test_utils import run_make, strip_ansi
+
+
+class TestReleasingTargets:
+    """Smoke tests for the releasing.mk targets."""
+
+    def test_changelog_target_dry_run(self, logger):
+        """Changelog target should generate CHANGELOG.md via git-cliff in dry-run output."""
+        proc = run_make(logger, ["changelog"])
+        out = proc.stdout
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert "git-cliff --output CHANGELOG.md" in out
+
+    def test_release_status_resolves_without_forge(self, logger):
+        """Release-status should resolve and report a missing forge when none is detected.
+
+        The temp repo has neither .github/workflows/ nor .gitlab-ci.yml, so
+        FORGE_TYPE is 'unknown' and the target prints the detection error while
+        still exiting cleanly (it must never be an undefined target).
+        """
+        proc = run_make(logger, ["release-status"])
+        assert "no rule to make target" not in proc.stderr.lower()
+        assert proc.returncode == 0
+        assert "Could not detect forge type" in strip_ansi(proc.stdout)
+
+    def test_release_status_delegates_to_github_views(self, root):
+        """On a GitHub forge, release-status should delegate to the workflow/release views."""
+        content = (root / ".rhiza" / "make.d" / "releasing.mk").read_text()
+        assert "ifeq ($(FORGE_TYPE),github)" in content, "release-status should branch on FORGE_TYPE"
+        github_branch = content.split("ifeq ($(FORGE_TYPE),github)", 1)[1].split("else", 1)[0]
+        assert "workflow-status" in github_branch, "GitHub branch should show workflow status"
+        assert "latest-release" in github_branch, "GitHub branch should show the latest release"
+
+    def test_release_status_warns_on_gitlab(self, root):
+        """On a GitLab forge, release-status should warn that it is unsupported rather than fail."""
+        content = (root / ".rhiza" / "make.d" / "releasing.mk").read_text()
+        assert "else ifeq ($(FORGE_TYPE),gitlab)" in content
+        gitlab_branch = content.split("else ifeq ($(FORGE_TYPE),gitlab)", 1)[1].split("else", 1)[0]
+        assert "not yet supported for GitLab" in gitlab_branch
+
+
+def test_release_targets_defined_in_make_d(root):
+    """Guard that the changelog/release-status targets are sourced from releasing.mk."""
+    releasing_mk = root / ".rhiza" / "make.d" / "releasing.mk"
+    assert releasing_mk.exists(), "releasing.mk should exist in .rhiza/make.d"
+    content = releasing_mk.read_text()
+    for target in ("changelog:", "release-status:"):
+        assert target in content, f"{target} should be defined in releasing.mk"

--- a/.rhiza/tests/conftest.py
+++ b/.rhiza/tests/conftest.py
@@ -18,15 +18,9 @@ import os
 import pathlib
 import shutil
 import subprocess  # nosec B404 - subprocess module needed for git operations in test fixtures
-import sys
 
 import pytest
-
-tests_root = pathlib.Path(__file__).resolve().parent
-if str(tests_root) not in sys.path:
-    sys.path.insert(0, str(tests_root))
-
-from test_utils import GIT  # noqa: E402
+from test_utils import GIT
 
 MOCK_MAKE_SCRIPT = """#!/usr/bin/env python3
 import sys

--- a/.rhiza/tests/structure/test_project_layout.py
+++ b/.rhiza/tests/structure/test_project_layout.py
@@ -32,9 +32,7 @@ class TestRootFixture:
         if not any((root / ci_dir).exists() for ci_dir in ci_dirs):
             pytest.fail(f"At least one CI directory from {ci_dirs} must exist")
 
-        # for dirname in optional_dirs:
-        #     if not (root / dirname).exists():
-        #         pytest.skip(f"Optional directory {dirname} not present in this project")
+        # Optional directories are not enforced in this shared layout test.
 
     def test_root_contains_expected_files(self, root):
         """Root should contain all expected configuration files."""
@@ -52,6 +50,6 @@ class TestRootFixture:
         for filename in required_files:
             assert (root / filename).exists(), f"Required file {filename} not found"
 
-        for filename in optional_files:
-            if not (root / filename).exists():
-                pytest.skip(f"Optional file {filename} not present in this project")
+        missing_optional_files = [filename for filename in optional_files if not (root / filename).exists()]
+        if missing_optional_files:
+            pytest.skip("Optional files not present in this project: " + ", ".join(missing_optional_files))

--- a/.rhiza/tests/sync/conftest.py
+++ b/.rhiza/tests/sync/conftest.py
@@ -14,16 +14,10 @@ from __future__ import annotations
 
 import os
 import shutil
-import sys
 from pathlib import Path
 
 import pytest
-
-tests_root = Path(__file__).resolve().parents[1]
-if str(tests_root) not in sys.path:
-    sys.path.insert(0, str(tests_root))
-
-from test_utils import run_make, setup_rhiza_git_repo, strip_ansi  # noqa: E402, F401
+from test_utils import setup_rhiza_git_repo
 
 
 @pytest.fixture(autouse=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
 testpaths = tests
+# Make the synced template test-suite importable (test_utils, api/, sync/, ...)
+# without each conftest manipulating sys.path at import time. Resolved relative
+# to rootdir; harmless when .rhiza/tests is absent.
+pythonpath = .rhiza/tests
 # Disable live logs on console by default (opt in with: pytest -o log_cli=true --log-cli-level=DEBUG)
 log_cli = false
 # Show DEBUG+ messages


### PR DESCRIPTION
## Summary
- Bumps the template `template-branch` to `v1.0.1` in `.rhiza/template.yml` (major bump, user-confirmed)
- Platform profile: `github-project` (unchanged — matches the GitHub origin)
- Runs `make sync` to apply upstream template changes; conflicts resolved taking upstream
- Rebased on `main`, which had meanwhile merged a v0.19.9 sync (#513) plus the two quality fixes (#516 version alignment, #517 SoftRisk coverage) — so this PR is now a clean v0.19.9 → v1.0.1 template bump. The duplicate fix commit was dropped during the rebase; issues #520 and #521 were closed as already resolved on main.

## Quality gates (re-verified after rebase)

| Gate | Result | Notes |
|---|---|---|
| `make fmt` | ✅ PASS | All pre-commit hooks green (ruff, markdownlint, bandit, actionlint, …) |
| `make typecheck` | ✅ PASS | `ty` + `mypy --strict`: no issues in 29 source files |
| `make docs-coverage` | ✅ PASS | interrogate 100.0% (minimum 100.0%) |
| `make deptry` | ✅ PASS | No dependency issues found |
| `make security` | ✅ PASS | pip-audit: no vulnerabilities; bandit clean |
| `make validate` | ✅ PASS | 180/180 rhiza tests; template.yml valid at v1.0.1 |
| `make test` | ✅ PASS | 56/56 passed; coverage 100% (gate 90%) |

## Scorecard

Scoped to locally-owned items (`src/`, `tests/`, `pyproject.toml`, project docs, `.rhiza/template.yml`); Rhiza-managed infrastructure is out of scope.

| Subcategory | Score | Evidence |
|---|---|---|
| Linting & style | 10/10 | Every ruff/markdownlint/pre-commit hook passes on the full tree |
| Type safety | 10/10 | Both `ty` and `mypy --strict` are clean over `src/` |
| Documentation (docstrings) | 10/10 | interrogate reports 100% docstring coverage at a 100% minimum |
| Security hygiene | 10/10 | pip-audit finds no vulnerable dependencies; bandit reports nothing |
| Dependency hygiene | 9/10 | deptry finds no issues, but emits ~16 "assuming module name" warnings for unmapped packages |
| Test pass rate | 10/10 | 56/56 project tests pass in under 5 s |
| Test coverage & depth | 10/10 | 100% coverage on `src/`, every module fully covered |
| Release / versioning hygiene | 10/10 | Git tag `v0.0.1` matches `[project].version`; `make validate` green |

**Overall: 9.9/10**

**Remaining improvement:** add a `[tool.deptry.package_module_name_map]` to `pyproject.toml` to silence deptry's module-name guessing warnings (cosmetic; deliberately not filed as an issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
