### PR TITLE
chore: add deptry package_module_name_map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,25 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/cvxmarkowitz"]
 
+[tool.deptry.package_module_name_map]
+cvxpy-base = "cvxpy"
+cvx-linalg = "cvx"
+cvxsimulator = "cvx"
+scikit-learn = "sklearn"
+numpy = "numpy"
+clarabel = "clarabel"
+fire = "fire"
+mock = "mock"
+yfinance = "yfinance"
+loguru = "loguru"
+tinycta = "tinycta"
+plotly = "plotly"
+marimo = "marimo"
+pytest = "pytest"
+ruff = "ruff"
+
 [tool.deptry.per_rule_ignores]
-DEP002 = ["cvxpy-base", "clarabel", "cvx-linalg"]
-DEP001 = ["cvx", "cvxpy"]
+DEP002 = ["clarabel", "cvx-linalg"]
 
 [tool.mypy]
 # cvxpy ships an incomplete py.typed surface: its functional atoms


### PR DESCRIPTION
## Summary
- Adds `[tool.deptry.package_module_name_map]` to `pyproject.toml`, mapping each dependency's dist name to its import name (`cvxpy-base` → `cvxpy`, `cvx-linalg`/`cvxsimulator` → `cvx`, `scikit-learn` → `sklearn`, plus identity entries) so `make deptry` no longer emits ~16 'Assuming the corresponding module name…' warnings.
- The explicit mappings let deptry resolve `import cvxpy` to `cvxpy-base`, retiring the `DEP001 = ["cvx", "cvxpy"]` ignore block and the `cvxpy-base` DEP002 entry. `clarabel` (solver backend, never imported) and `cvx-linalg` (used only in `tests/`, which deptry doesn't scan) keep their DEP002 ignores.

## Verification
- `make deptry`: no warnings, no dependency issues
- `make fmt`: all hooks pass (incl. pyproject validation)

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)