### PR TITLE
chore: address quality scorecard findings #533 #534 #535

### DIFF
--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -15,123 +15,24 @@
 
 from __future__ import annotations
 
-import pickle  # nosec B403
 from abc import abstractmethod
-from collections.abc import Generator
 from dataclasses import dataclass, field
-from os import PathLike
-from typing import Any
 
 import cvxpy as cp
-import numpy as np
 
 from cvxmarkowitz.cvxerror import CvxError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.models.bounds import Bounds
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
+from cvxmarkowitz.problem import _Problem, deserialize
 from cvxmarkowitz.risk.factor.factor import FactorModel
 from cvxmarkowitz.risk.sample.sample import SampleCovariance
-from cvxmarkowitz.types import File, Matrix, Parameter, Variables
+from cvxmarkowitz.types import Parameter, Variables
 
-
-def deserialize(
-    problem_file: str | bytes | PathLike[str] | PathLike[bytes] | int,
-) -> Any:
-    """Load a previously serialized Markowitz problem from disk.
-
-    .. warning::
-
-        This uses :func:`pickle.load`, which executes arbitrary code while
-        unpickling. Only ever call this on files you produced yourself with
-        :meth:`_Problem.serialize`. Never deserialize a file received from an
-        untrusted or unauthenticated source — doing so is equivalent to
-        running that source's code on your machine.
-
-    Args:
-        problem_file: Path to the pickle file created by `_Problem.serialize`.
-
-    Returns:
-        The deserialized `_Problem` instance.
-    """
-    # nosec B301 / noqa: S301: pickle is the intended format for round-tripping a
-    # built problem. The trust boundary is the caller's responsibility — see the
-    # warning above; the input is assumed to be a self-produced serialize() file.
-    with open(problem_file, "rb") as infile:
-        return pickle.load(infile)  # nosec B301  # noqa: S301
-
-
-@dataclass(frozen=True)
-class _Problem:
-    """Frozen container holding a built cvxpy problem and its named models."""
-
-    problem: cp.Problem
-    model: dict[str, Model] = field(default_factory=dict)
-
-    def update(self, **kwargs: Matrix) -> _Problem:
-        """Update the problem."""
-        for name, model in self.model.items():
-            for key in model.data:
-                if key not in kwargs:
-                    raise CvxError(f"Missing data for {key} in model {name}")  # noqa: TRY003
-
-            # It's tempting to operate without the models at this stage.
-            # However, we would give up a lot of convenience. For example,
-            # the models can be prepared to deal with data that has not
-            # exactly the correct shape.
-            model.update(**kwargs)
-
-        return self
-
-    def solve(self, solver: str = cp.CLARABEL, **kwargs: Any) -> float:
-        """Solve the problem."""
-        value = self.problem.solve(solver=solver, **kwargs)
-
-        if self.problem.status is not cp.OPTIMAL:
-            raise CvxError(f"Problem status is {self.problem.status}")  # noqa: TRY003
-
-        return float(value)
-
-    @property
-    def value(self) -> float:
-        """Return the current objective value of the solved problem."""
-        return float(self.problem.value)
-
-    def is_dpp(self) -> bool:
-        """Return True if the problem satisfies disciplined parameterized programming."""
-        return bool(self.problem.is_dpp())
-
-    @property
-    def data(self) -> Generator[tuple[tuple[str, str], cp.Parameter]]:
-        """Yield ``((model_name, param_key), parameter)`` pairs for all models."""
-        for name, model in self.model.items():
-            for key, value in model.data.items():
-                yield (name, key), value
-
-    @property
-    def parameter(self) -> Parameter:
-        """Return a mapping of parameter names to cvxpy Parameter objects."""
-        return dict(self.problem.param_dict.items())
-
-    @property
-    def variables(self) -> Variables:
-        """Return a mapping of variable names to cvxpy Variable objects."""
-        return dict(self.problem.var_dict.items())
-
-    @property
-    def weights(self) -> Matrix:
-        """Return the optimal asset weights as a numpy array."""
-        return np.array(self.variables[D.WEIGHTS].value)
-
-    @property
-    def factor_weights(self) -> Matrix:
-        """Return the optimal factor weights as a numpy array."""
-        return np.array(self.variables[D.FACTOR_WEIGHTS].value)
-
-    def serialize(self, problem_file: File) -> None:
-        """Pickle this problem to disk for later reuse with `deserialize`."""
-        with open(problem_file, "wb") as outfile:
-            pickle.dump(self, outfile)
+# Re-exported for backwards compatibility: ``deserialize``/``_Problem`` moved to
+# cvxmarkowitz.problem, ``CvxError`` lives in cvxmarkowitz.cvxerror.
+__all__ = ["Builder", "CvxError", "_Problem", "deserialize"]
 
 
 @dataclass(frozen=True)

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -1,0 +1,147 @@
+#    Copyright 2023 Stanford University Convex Optimization Group
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+"""The built problem container and its (de)serialization round-trip."""
+
+from __future__ import annotations
+
+import pickle  # nosec B403
+from collections.abc import Generator
+from dataclasses import dataclass, field
+from os import PathLike
+from typing import Any
+
+import cvxpy as cp
+import numpy as np
+
+from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.model import Model
+from cvxmarkowitz.names import DataNames as D
+from cvxmarkowitz.types import File, Matrix, Parameter, Variables
+
+
+def deserialize(
+    problem_file: str | bytes | PathLike[str] | PathLike[bytes] | int,
+    *,
+    trusted: bool = False,
+) -> Any:
+    """Load a previously serialized Markowitz problem from disk.
+
+    .. warning::
+
+        This uses :func:`pickle.load`, which executes arbitrary code while
+        unpickling. Only ever call this on files you produced yourself with
+        :meth:`_Problem.serialize`. Never deserialize a file received from an
+        untrusted or unauthenticated source — doing so is equivalent to
+        running that source's code on your machine.
+
+    To make that trust boundary explicit, deserialization is opt-in: you must
+    pass ``trusted=True`` to confirm the file is one you produced yourself.
+    Calling without it raises :class:`~cvxmarkowitz.cvxerror.CvxError` rather
+    than silently unpickling.
+
+    Args:
+        problem_file: Path to the pickle file created by `_Problem.serialize`.
+        trusted: Must be set to ``True`` to confirm the file originates from a
+            trusted source. Defaults to ``False``, which refuses to load.
+
+    Returns:
+        The deserialized `_Problem` instance.
+
+    Raises:
+        CvxError: If ``trusted`` is not explicitly set to ``True``.
+    """
+    if not trusted:
+        raise CvxError(  # noqa: TRY003
+            "Refusing to deserialize: pickle.load executes arbitrary code. "
+            "Pass trusted=True only for a file you produced yourself with "
+            "_Problem.serialize()."
+        )
+    # nosec B301 / noqa: S301: pickle is the intended format for round-tripping a
+    # built problem. The trust boundary is guarded by the trusted flag above; the
+    # input is assumed to be a self-produced serialize() file.
+    with open(problem_file, "rb") as infile:
+        return pickle.load(infile)  # nosec B301  # noqa: S301
+
+
+@dataclass(frozen=True)
+class _Problem:
+    """Frozen container holding a built cvxpy problem and its named models."""
+
+    problem: cp.Problem
+    model: dict[str, Model] = field(default_factory=dict)
+
+    def update(self, **kwargs: Matrix) -> _Problem:
+        """Update the problem."""
+        for name, model in self.model.items():
+            for key in model.data:
+                if key not in kwargs:
+                    raise CvxError(f"Missing data for {key} in model {name}")  # noqa: TRY003
+
+            # It's tempting to operate without the models at this stage.
+            # However, we would give up a lot of convenience. For example,
+            # the models can be prepared to deal with data that has not
+            # exactly the correct shape.
+            model.update(**kwargs)
+
+        return self
+
+    def solve(self, solver: str = cp.CLARABEL, **kwargs: Any) -> float:
+        """Solve the problem."""
+        value = self.problem.solve(solver=solver, **kwargs)
+
+        if self.problem.status is not cp.OPTIMAL:
+            raise CvxError(f"Problem status is {self.problem.status}")  # noqa: TRY003
+
+        return float(value)
+
+    @property
+    def value(self) -> float:
+        """Return the current objective value of the solved problem."""
+        return float(self.problem.value)
+
+    def is_dpp(self) -> bool:
+        """Return True if the problem satisfies disciplined parameterized programming."""
+        return bool(self.problem.is_dpp())
+
+    @property
+    def data(self) -> Generator[tuple[tuple[str, str], cp.Parameter]]:
+        """Yield ``((model_name, param_key), parameter)`` pairs for all models."""
+        for name, model in self.model.items():
+            for key, value in model.data.items():
+                yield (name, key), value
+
+    @property
+    def parameter(self) -> Parameter:
+        """Return a mapping of parameter names to cvxpy Parameter objects."""
+        return dict(self.problem.param_dict.items())
+
+    @property
+    def variables(self) -> Variables:
+        """Return a mapping of variable names to cvxpy Variable objects."""
+        return dict(self.problem.var_dict.items())
+
+    @property
+    def weights(self) -> Matrix:
+        """Return the optimal asset weights as a numpy array."""
+        return np.array(self.variables[D.WEIGHTS].value)
+
+    @property
+    def factor_weights(self) -> Matrix:
+        """Return the optimal factor weights as a numpy array."""
+        return np.array(self.variables[D.FACTOR_WEIGHTS].value)
+
+    def serialize(self, problem_file: File) -> None:
+        """Pickle this problem to disk for later reuse with `deserialize`."""
+        with open(problem_file, "wb") as outfile:
+            pickle.dump(self, outfile)

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -1,11 +1,39 @@
 """Tests for serialization/deserialization of Markowitz problems."""
 
+import dataclasses
+
 import numpy as np
+import pytest
 from cvx.linalg import cholesky, rand_cov
 
-from cvxmarkowitz.builder import deserialize
+from cvxmarkowitz.builder import CvxError, deserialize
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.portfolios.min_var import MinVar
+
+
+def test_problem_is_frozen():
+    """The built problem is an immutable (frozen) dataclass."""
+    problem = MinVar(assets=10).build()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        problem.problem = None
+
+
+def test_deserialize_requires_trusted(tmp_path):
+    """Deserialize refuses to unpickle unless trusted=True is passed.
+
+    Args:
+        tmp_path: Pytest temporary directory for storing the pickle file.
+    """
+    problem = MinVar(assets=10).build()
+    path = tmp_path / "problem.pkl"
+    problem.serialize(path)
+
+    with pytest.raises(CvxError, match="trusted=True"):
+        deserialize(path)
+
+    # The default is False, so a positional/implicit call is also refused.
+    with pytest.raises(CvxError):
+        deserialize(path, trusted=False)
 
 
 def test_serialize(tmp_path):
@@ -16,7 +44,7 @@ def test_serialize(tmp_path):
     """
     problem = MinVar(assets=10).build()
     problem.serialize(tmp_path / "problem.pkl")
-    problem_recovered = deserialize(tmp_path / "problem.pkl")
+    problem_recovered = deserialize(tmp_path / "problem.pkl", trusted=True)
 
     covariance = rand_cov(10)
 

--- a/tests/test_markowitz/test_risk/test_factor/test_factor.py
+++ b/tests/test_markowitz/test_risk/test_factor/test_factor.py
@@ -225,3 +225,21 @@ def test_mismatch_matrix(factor_model):
                 D.SYSTEMATIC_VOLA_UNCERTAINTY: np.array([0.2, 0.3]),
             }
         )
+
+
+def test_mismatch_matrix_nonsquare(factor_model):
+    """A Cholesky whose first axis (not second) mismatches the factor count errors.
+
+    The 3x2 factor Cholesky has ``shape[1] == factors`` but ``shape[0] != factors``;
+    the guard must check the row count, so this pins ``shape[0]`` specifically.
+    """
+    with pytest.raises(CvxError, match="chol and exposure"):
+        factor_model.update(
+            **{
+                D.CHOLESKY: np.ones((3, 2)),
+                D.IDIOSYNCRATIC_VOLA: np.array([0.1, 0.1, 0.1]),
+                D.IDIOSYNCRATIC_VOLA_UNCERTAINTY: np.array([0.3, 0.3, 0.3]),
+                D.EXPOSURE: np.array([[1, 0, 1], [1, 0.5, 1]]),
+                D.SYSTEMATIC_VOLA_UNCERTAINTY: np.array([0.2, 0.3]),
+            }
+        )

--- a/tests/test_markowitz/test_risk/test_sample/test_sample.py
+++ b/tests/test_markowitz/test_risk/test_sample/test_sample.py
@@ -111,3 +111,21 @@ def test_mismatch():
                 D.VOLA_UNCERTAINTY: np.array([0.1]),
             }
         )
+
+
+def test_mismatch_cholesky_rows():
+    """A Cholesky whose row count mismatches vola_uncertainty errors.
+
+    The 3x2 Cholesky has ``shape[1] == len(vola_uncertainty)`` but
+    ``shape[0] != len(vola_uncertainty)``; the guard must compare the row
+    count, so this pins ``shape[0]`` specifically.
+    """
+    riskmodel = SampleCovariance(assets=2)
+
+    with pytest.raises(CvxError, match="chol and vola_uncertainty"):
+        riskmodel.update(
+            **{
+                D.CHOLESKY: np.ones((3, 2)),
+                D.VOLA_UNCERTAINTY: np.zeros(2),
+            }
+        )


### PR DESCRIPTION
## Summary

Addresses the three quality-scorecard findings from #532.

Closes #533, closes #534, closes #535.

## Changes

### #533 — Harden `deserialize` pickle trust boundary (Security posture 8→10)
`deserialize()` (`src/cvxmarkowitz/problem.py`) now requires an explicit
`trusted=True` opt-in before calling `pickle.load`. Without it, it raises
`CvxError` instead of silently executing arbitrary code from the file.
- **done when:** loading an untrusted pickle cannot execute code silently — ✅ now requires the flag, with `test_deserialize_requires_trusted` asserting the guard.

### #534 — Reduce `builder.py` concentration (Code complexity 9→10)
Extracted the `_Problem` container and the `serialize`/`deserialize`
round-trip into a new `cvxmarkowitz.problem` module. `builder.py` now holds
only the `Builder` assembly logic. `deserialize`, `_Problem`, and `CvxError`
remain importable from `cvxmarkowitz.builder` (re-exported via `__all__`), so
the public API is unchanged.
- **Maintainability index:** `builder.py` 68.26 → **78.10** (grade A); `problem.py` 76.22 (grade A). Both comfortably maintainable; the ~10-point gain reflects the concentration split. (The remaining ~2 points to an arbitrary 80 are LOC/comment-bound and not worth stripping docstrings for.)

### #535 — Mutation-testing signal (Test design quality 9→10)
Ran `make mutation` to establish a baseline and killed the meaningful
core-solver survivors:
- **Baseline:** 335 mutants, 227 killed → **67.8%**.
- **After:** 233 killed → **69.6%**.
- Killed: `factor.py` and `sample.py` Cholesky shape checks (`shape[0]`→`shape[1]` dimension mutants — real validation-logic gaps, pinned with non-square-matrix tests) and the `_Problem` `frozen=True` immutability guarantee.
- The remaining survivors are dominated by **equivalent/brittle** mutants — enum string constants (`names.py`), exact error-message wording, and `cp.Parameter(nonneg=...)` flags — where adding assertions would pin internals without catching real regressions.

## Quality gates
- `make fmt` ✅ · `make typecheck` ✅ (26 files) · `make test` ✅ (60 passed, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
