### PR TITLE
Show the coverage badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/cvxmarkowitz.svg)](https://badge.fury.io/py/cvxmarkowitz)
 [![Apache 2.0 License](https://img.shields.io/badge/License-APACHEv2-brightgreen.svg)](https://github.com/cvxgrp/cvxmarkowitz/blob/master/LICENSE)
 [![PyPI download month](https://img.shields.io/pypi/dm/cvxmarkowitz.svg)](https://pypi.python.org/pypi/cvxmarkowitz/)
+[![Coverage](https://www.cvxgrp.org/cvxmarkowitz/coverage-badge.svg)](https://www.cvxgrp.org/cvxmarkowitz/reports/html-coverage/)
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/cvxgrp/cvxmarkowitz)
 


### PR DESCRIPTION
Coverage is already measured, published and sitting at **100%** — the badge SVG and the HTML report are both live — but the README never linked either, so the number was reachable only by knowing the URL.

It also left the coverage column blank for this row in the [tschm profile table](https://github.com/tschm/tschm), which harvests the badge from each repository's own README rather than reconstructing it, so that a project decides for itself what it publishes and under which URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)