### PR TITLE
chore: update rhiza to v1.3.2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Closes #<!-- issue number -->
 - [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
 - [ ] `CHANGELOG.md` entry added (or not needed for this change)
 - [ ] Documentation updated if behaviour changed
-- [ ] `make deptry` passes (no unused or missing dependencies)
+- [ ] `make deps` passes (no unused or missing dependencies)

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -27,12 +27,12 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
-          { "context": "Pre-commit hooks", "integration_id": 15368 },
-          { "context": "Check dependencies with deptry", "integration_id": 15368 },
-          { "context": "docs-coverage", "integration_id": 15368 },
-          { "context": "Security scanning", "integration_id": 15368 },
-          { "context": "License compliance scan", "integration_id": 15368 },
-          { "context": "CI gate", "integration_id": 15368 }
+          { "context": "ci / Pre-commit hooks", "integration_id": 15368 },
+          { "context": "ci / Check dependencies with deptry", "integration_id": 15368 },
+          { "context": "ci / docs-coverage", "integration_id": 15368 },
+          { "context": "ci / Security scanning", "integration_id": 15368 },
+          { "context": "ci / License compliance scan", "integration_id": 15368 },
+          { "context": "ci / CI gate", "integration_id": 15368 }
         ]
       }
     }

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.2
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.2
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.2
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.2
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.2
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -156,6 +156,48 @@ jobs:
             fi
           fi
 
+      - name: Ensure the tagged commit is reachable from a branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.set_tag.outputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          # Backstop for issue #1454: a release cut on a branch that is then
+          # squash-merged leaves the tag on the pre-squash commit, and the squash
+          # puts the same content on the default branch under a new SHA. The tag is
+          # then permanently orphaned — no branch contains it, `git describe` skips
+          # the release, and a git-cliff regeneration silently deletes that version's
+          # CHANGELOG section because it cannot place a boundary at an unreachable
+          # tag. Publishing from such a tag is never intended, so refuse it.
+          # The checkout above uses fetch-depth: 0; this fetch only adds the remote
+          # branch refs, which a tag-push checkout does not need otherwise.
+          git fetch --no-tags --quiet origin '+refs/heads/*:refs/remotes/origin/*'
+
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+          fi
+          if ! git rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null; then
+            echo "::error::Cannot resolve the default branch 'origin/$DEFAULT_BRANCH' — refusing to release without a reachability check."
+            exit 1
+          fi
+
+          COMMIT=$(git rev-parse "$TAG^{commit}")
+          if git merge-base --is-ancestor "$COMMIT" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "✅ $TAG ($COMMIT) is an ancestor of $DEFAULT_BRANCH"
+            exit 0
+          fi
+
+          # Reachable from some other branch: a maintenance/hotfix release. Legitimate,
+          # but a changelog regenerated from the default branch still cannot see it.
+          BRANCHES=$(git branch -r --contains "$COMMIT" --format='%(refname:short)')
+          if [ -n "$BRANCHES" ]; then
+            echo "::warning::Tag $TAG is not an ancestor of $DEFAULT_BRANCH; it is contained in: $(echo "$BRANCHES" | tr '\n' ' '). A CHANGELOG regenerated from $DEFAULT_BRANCH will not include this release."
+            exit 0
+          fi
+
+          echo "::error::Tag $TAG points at $COMMIT, which no branch contains. It is most likely a pre-squash commit from a squash-merged release branch: re-tag the merged commit on $DEFAULT_BRANCH and delete this tag (issue #1454)."
+          exit 1
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7.6.0
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.2
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.5
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.2
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,9 @@ local.mk
 
 .bandit-baseline.json
 
+
+# Rust (rust-core bundle). Kept in core rather than the language layer because
+# .gitignore has one owner and git opens it with O_NOFOLLOW, so it cannot be a
+# per-layer file. These entries are inert in a Python repo.
+target/
+**/*.rs.bk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.0'
+    rev: 'v0.16.1'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -71,12 +71,12 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: v1.7.2
+    rev: v1.7.3
     hooks:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.0
+    rev: 0.12.1
     hooks:
       - id: uv-lock
 
@@ -88,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.7.0  # Use the latest release
+    rev: v1.2.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -97,4 +97,14 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
+      # check-bumpversion-config asserts that bump-my-version can actually discover the
+      # project's version config (issue #1453) — for this layer, the [tool.bumpversion]
+      # table in pyproject.toml, since python-core deliberately ships no .bumpversion.toml.
+      # It ships as of v1.1.0; it stays off because the .rhiza/tests/test_pyproject.py this
+      # layer also ships enforces the same invariant one gate later.
+      # - id: check-bumpversion-config
+      # check-template-bundles validates .rhiza/template.yml against the template repo's
+      # remote bundle list, so it fires only when that file is staged — and unlike in the
+      # mother repo (which has no template.yml) it is live in a synced project. Disabled in
+      # #660 (rhiza-hooks 0.3.0) with no reason recorded.
       # - id: check-template-bundles

--- a/.rhiza/CONTRIBUTING.md
+++ b/.rhiza/CONTRIBUTING.md
@@ -67,6 +67,9 @@ uv sync --group docs        # docs/notebook stack (marimo, numpy, pandas, plotly
 uv sync --all-groups        # full development environment
 ```
 
+There is no `lint` group: `make fmt` runs the hooks through prek, which provisions each
+linter itself, so there is nothing for such a group to install.
+
 ## Contributing code
 
 To contribute to the project, send us pull requests.

--- a/.rhiza/make.d/bootstrap.mk
+++ b/.rhiza/make.d/bootstrap.mk
@@ -1,11 +1,13 @@
 ## .rhiza/make.d/bootstrap.mk - Bootstrap and Installation
-# This file provides targets for setting up the development environment,
-# installing dependencies, and cleaning project artifacts.
+# This file provides the language-neutral half of setup: it puts uv/uvx on the
+# path (rhiza runs pre-commit, mkdocs and semgrep through uvx whatever the
+# project is written in), declares the install hooks, and cleans artifacts.
+#
+# `install` itself belongs to the language layer, because what it means differs:
+# python.mk (bundle python-core) creates a virtualenv and runs `uv sync`.
 
 # Declare phony targets (they don't produce files)
-.PHONY: install-uv install clean pre-install post-install
-
-UV_SYNC_ARGS ?= --all-extras --all-groups
+.PHONY: install-uv clean pre-install post-install
 
 # Hook targets (double-colon rules allow multiple definitions)
 pre-install:: ; @:
@@ -28,55 +30,6 @@ install-uv: ## ensure uv/uvx is installed
 	    exit 1; \
 	  fi; \
 	fi
-
-install: pre-install install-uv ## install
-	# Create the virtual environment only if it doesn't exist
-	@if [ ! -d "${VENV}" ]; then \
-	  ${UV_BIN} venv $(if $(PYTHON_VERSION),--python $(PYTHON_VERSION)) ${VENV} || { printf "${RED}[ERROR] Failed to create virtual environment${RESET}\n"; exit 1; }; \
-	else \
-	  printf "${BLUE}[INFO] Using existing virtual environment at ${VENV}, skipping creation${RESET}\n"; \
-	fi
-
-	# Install the dependencies from pyproject.toml (if it exists).
-	# --inexact leaves packages uv did not manage in place instead of pruning them each
-	# run, so repeated 'make' targets don't churn the environment. Per-target tooling
-	# (pytest, interrogate, mutmut, ...) is provisioned on the fly via `uv run --with`
-	# in the individual targets, so there is no separate dependency-install step here.
-	@if [ -f "pyproject.toml" ]; then \
-	  if [ -f "uv.lock" ]; then \
-	    if ! ${UV_BIN} lock --check >/dev/null 2>&1; then \
-	      printf "${YELLOW}[WARN] uv.lock is out of sync with pyproject.toml${RESET}\n"; \
-	      printf "${YELLOW}       Run 'uv sync' to update your lock file and environment${RESET}\n"; \
-	      printf "${YELLOW}       Or run 'uv lock' to update only the lock file${RESET}\n"; \
-	      exit 1; \
-	    fi; \
-	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
-	  else \
-	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
-	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
-	  fi; \
-	else \
-	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \
-	fi
-
-	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
-	# external hook manager — pre-commit refuses to install in that case)
-	@if [ -f ".pre-commit-config.yaml" ]; then \
-	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
-	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
-	  else \
-	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
-	    ${UVX_BIN} -p ${PYTHON_VERSION} pre-commit install || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
-	  fi; \
-	fi
-
-	@$(MAKE) post-install
-	
-	# Display success message with activation instructions
-	@printf "\n${GREEN}[SUCCESS] Installation complete!${RESET}\n\n"
-	@printf "${BLUE}To activate the virtual environment, run:${RESET}\n"
-	@printf "${YELLOW}  source ${VENV}/bin/activate${RESET}\n\n"
 
 clean: ## Clean project artifacts and stale local branches
 	@printf "%bCleaning project...%b\n" "$(BLUE)" "$(RESET)"

--- a/.rhiza/make.d/doctor.mk
+++ b/.rhiza/make.d/doctor.mk
@@ -1,9 +1,18 @@
 ## .rhiza/make.d/doctor.mk - Developer prerequisite diagnostics
+#
+# Core checks only the tools it needs whatever the language: uv, make, git. A language
+# layer appends its own diagnostics with a second `doctor::` rule — double-colon, like
+# `pre-install::` and `test::`, so each rule runs in turn and a layer never has to know
+# what core already checked. rust.mk uses this to catch a cargo that is not
+# rustup-managed, which no version check would notice.
+#
+# Each rule runs in its own shell, so `failed` below is local to this one: a layer's rule
+# reports and exits on its own account, and `make doctor` fails if any rule does.
 
 .PHONY: doctor
 
 ##@ Dev
-doctor: ## verify local prerequisites and print actionable guidance
+doctor:: ## verify local prerequisites and print actionable guidance
 	@failed=0; \
 	version_ge() { \
 		awk -v a="$$1" -v b="$$2" 'BEGIN { \
@@ -21,20 +30,20 @@ doctor: ## verify local prerequisites and print actionable guidance
 	check_tool() { \
 		tool="$$1"; min="$$2"; install_url="$$3"; version_cmd="$$4"; gnu_required="$$5"; \
 		if ! command -v "$$tool" >/dev/null 2>&1; then \
-			printf "${RED}[❌]${RESET} %-9s missing — install: %s\n" "$$tool" "$$install_url"; \
+			printf "${RED}[FAIL]${RESET} %-11s missing - install: %s\n" "$$tool" "$$install_url"; \
 			failed=1; \
 			return; \
 		fi; \
 		version="$$(eval "$$version_cmd" 2>/dev/null)"; \
 		if [ -z "$$version" ]; then \
-			printf "${RED}[❌]${RESET} %-9s unknown version (required ≥ %s)\n" "$$tool" "$$min"; \
+			printf "${RED}[FAIL]${RESET} %-11s unknown version (required >= %s)\n" "$$tool" "$$min"; \
 			failed=1; \
 			return; \
 		fi; \
 		extra=""; \
 		if [ "$$gnu_required" = "gnu" ] && ! make --version 2>/dev/null | grep -q '^GNU Make'; then \
 			extra=" (GNU required)"; \
-			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			printf "${RED}[FAIL]${RESET} %-11s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
 			failed=1; \
 			return; \
 		fi; \
@@ -42,12 +51,12 @@ doctor: ## verify local prerequisites and print actionable guidance
 			if [ "$$gnu_required" = "gnu" ]; then \
 				extra=" (GNU required)"; \
 			fi; \
-			printf "${GREEN}[✅]${RESET} %-9s %-8s ≥ %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			printf "${GREEN}[ OK ]${RESET} %-11s %-8s >= %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
 		else \
 			if [ "$$gnu_required" = "gnu" ]; then \
 				extra=" (GNU required)"; \
 			fi; \
-			printf "${RED}[❌]${RESET} %-9s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
+			printf "${RED}[FAIL]${RESET} %-11s %-8s < %s%s\n" "$$tool" "$$version" "$$min" "$$extra"; \
 			failed=1; \
 		fi; \
 	}; \

--- a/.rhiza/make.d/python.mk
+++ b/.rhiza/make.d/python.mk
@@ -1,0 +1,284 @@
+## .rhiza/make.d/python.mk - the Python language layer (bundle: python-core)
+#
+# Everything in rhiza that only makes sense because the project is written in
+# Python. `core` provides the make framework and uv/uvx as a tool runner; this
+# file turns that into a Python project: the virtualenv, the `install` that syncs
+# it, dependency and licence analysis of the declared dependencies, and the `all`
+# aggregate naming the gates.
+#
+# A sibling language layer (rust.mk, from a rust-core bundle) ships the same
+# *target names* — install, all — with different recipes. That contract is the
+# reason book.mk and the CI workflows can call `make install` without knowing the
+# language. Only one language layer is ever synced into a repo.
+#
+# Every gate named in `all` below is defined *here*, which is what makes this file
+# comparable to rust.mk and go.mk. Until #1475 four of them — test, typecheck,
+# security, docs-coverage — lived in the `tests` bundle's test.mk while `all` named
+# them, so a project syncing `core + python-core` without `tests` had an `all` that
+# could not run. The `tests` bundle now carries only the genuinely optional extras
+# (benchmark, hypothesis-test, stress, mutation).
+
+# Declare phony targets (they don't produce files)
+.PHONY: all deps deptry docs-coverage install license security test test-pyproject typecheck
+
+# The project virtualenv, and the interpreter that fills it. PYTHON_VERSION is
+# declared in rhiza.mk (core needs a Python to run its own tooling on); here
+# `.python-version` — which this bundle ships — makes it the project's version too.
+VENV ?= .venv
+UV_SYNC_ARGS ?= --all-extras --all-groups
+
+export UV_VENV_CLEAR := 1
+
+# Configurable list of licenses that fail the compliance scan (semicolon-separated)
+LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
+
+# Default directory for tests. Also read by the `tests` bundle's test.mk, which
+# requires this layer, so the two never disagree about where tests live.
+TESTS_FOLDER := tests
+
+# Minimum coverage percent for tests to pass
+# (Can be overridden in local.mk or via environment variable)
+COVERAGE_FAIL_UNDER ?= 90
+
+# Which static type checker(s) the 'typecheck' target runs: ty, mypy, or both.
+# Running both is the default for backward compatibility, but ty and mypy
+# occasionally disagree (e.g. one accepts a suppression the other still flags),
+# forcing duplicate `# type: ignore` / `# ty: ignore` comments. Set this to
+# 'ty' or 'mypy' in local.mk or .rhiza/.env to run a single checker instead.
+TYPECHECKER ?= both
+
+##@ Python
+install: pre-install install-uv ## install
+	# Create the virtual environment only if it doesn't exist
+	@if [ ! -d "${VENV}" ]; then \
+	  ${UV_BIN} venv $(if $(PYTHON_VERSION),--python $(PYTHON_VERSION)) ${VENV} || { printf "${RED}[ERROR] Failed to create virtual environment${RESET}\n"; exit 1; }; \
+	else \
+	  printf "${BLUE}[INFO] Using existing virtual environment at ${VENV}, skipping creation${RESET}\n"; \
+	fi
+
+	# Install the dependencies from pyproject.toml (if it exists).
+	# --inexact leaves packages uv did not manage in place instead of pruning them each
+	# run, so repeated 'make' targets don't churn the environment. Per-target tooling
+	# (pytest, interrogate, mutmut, ...) is provisioned on the fly via `uv run --with`
+	# in the individual targets, so there is no separate dependency-install step here.
+	@if [ -f "pyproject.toml" ]; then \
+	  if [ -f "uv.lock" ]; then \
+	    if ! ${UV_BIN} lock --check >/dev/null 2>&1; then \
+	      printf "${YELLOW}[WARN] uv.lock is out of sync with pyproject.toml${RESET}\n"; \
+	      printf "${YELLOW}       Run 'uv sync' to update your lock file and environment${RESET}\n"; \
+	      printf "${YELLOW}       Or run 'uv lock' to update only the lock file${RESET}\n"; \
+	      exit 1; \
+	    fi; \
+	    printf "${BLUE}[INFO] Installing dependencies from lock file${RESET}\n"; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact --frozen || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	  else \
+	    printf "${YELLOW}[WARN] uv.lock not found. Generating lock file and installing dependencies...${RESET}\n"; \
+	    ${UV_BIN} sync $(UV_SYNC_ARGS) --inexact || { printf "${RED}[ERROR] Failed to install dependencies${RESET}\n"; exit 1; }; \
+	  fi; \
+	else \
+	  printf "${YELLOW}[WARN] No pyproject.toml found, skipping install${RESET}\n"; \
+	fi
+
+	# Install pre-commit hooks (skip when core.hooksPath is set, e.g. by an
+	# external hook manager — pre-commit refuses to install in that case)
+	#
+	# `-c` for the reason quality.mk's `fmt` passes `--config`, and it must be repeated
+	# here: prek bakes the flag into the generated shim, so without it the commit-time
+	# gate rediscovers nested projects and stops meaning what `make fmt` means. A
+	# consumer who wants prek's monorepo behaviour drops the flag from both places.
+	@if [ -f ".pre-commit-config.yaml" ]; then \
+	  if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
+	    printf "${BLUE}[INFO] Skipping pre-commit hook install: core.hooksPath is set${RESET}\n"; \
+	  else \
+	    printf "${BLUE}[INFO] Installing pre-commit hooks...${RESET}\n"; \
+	    ${UVX_BIN} prek install -c .pre-commit-config.yaml || { printf "${YELLOW}[WARN] Failed to install pre-commit hooks${RESET}\n"; }; \
+	  fi; \
+	fi
+
+	@$(MAKE) post-install
+	
+	# Display success message with activation instructions
+	@printf "\n${GREEN}[SUCCESS] Installation complete!${RESET}\n\n"
+	@printf "${BLUE}To activate the virtual environment, run:${RESET}\n"
+	@printf "${YELLOW}  source ${VENV}/bin/activate${RESET}\n\n"
+
+all: fmt deps test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
+
+# deptry scans one or more folders for dependency issues. Each feature bundle
+# contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
+# to DEPTRY_IGNORE), so this target never needs to know which bundles are
+# present. The language layer itself contributes SOURCE_FOLDER when it exists; see e.g.
+# marimo.mk for a bundle that appends its own folder. Rhiza's own test folder
+# (.rhiza/tests) is deliberately excluded: its tooling is provisioned on the fly
+# via `uv run --with` in the individual targets, not declared in the project's
+# pyproject, so deptry (which validates against pyproject) would only emit noise
+# for it.
+DEPTRY_FOLDERS ?=
+DEPTRY_IGNORE ?=
+ifneq ($(wildcard $(SOURCE_FOLDER)),)
+DEPTRY_FOLDERS += $(SOURCE_FOLDER)
+endif
+
+# Named `deps`, matching rust.mk and go.mk. This was the one gate whose *target name*
+# differed by language (#1474): `deptry` names the tool, which nothing else in the
+# contract does — pytest is `test`, mypy is `typecheck`, bandit is `security`. So
+# `make deps` used to fail on a Python project and `make deptry` on the other two, and
+# nothing language-neutral could invoke the gate without knowing the language first.
+#
+# The variables stay `DEPTRY_*`: they name the tool's *arguments*, honestly so —
+# marimo.mk appends `--ignore DEP004`, a deptry rule code — and they are the accumulator
+# interface a downstream local.mk writes to, so renaming them would break consumers for
+# nothing.
+deps: install-uv ## Run deptry over the folders contributed by each bundle
+	@if [ -n "$(strip $(DEPTRY_FOLDERS))" ]; then \
+		printf "${BLUE}[INFO] Running deptry on:${RESET} $(strip $(DEPTRY_FOLDERS))\n"; \
+		$(UVX_BIN) -p ${PYTHON_VERSION} deptry $(strip $(DEPTRY_FOLDERS) $(DEPTRY_IGNORE)); \
+	else \
+		printf "${YELLOW}[WARN] no deptry folders found, skipping.${RESET}\n"; \
+	fi
+
+# Deprecated alias. A downstream local.mk, a hand-written CI job or a contributor's
+# muscle memory all still call `make deptry`; a hard rename would break them at the
+# point where the gate simply stops existing. Warns rather than failing, and can go in
+# a future release once consumers have moved.
+deptry: ## deprecated alias for `deps`
+	@printf "${YELLOW}[WARN] \`make deptry\` is deprecated and will be removed; use \`make deps\`.${RESET}\n"
+	@$(MAKE) --no-print-directory deps
+
+license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
+	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"
+	@${UV_BIN} run --with pip-licenses pip-licenses --fail-on="${LICENSE_FAIL_ON}"
+
+##@ Development and Testing
+
+# The 'test' target runs the complete test suite.
+# 1. Cleans up any previous test results in _tests/ and stale coverage data.
+# 2. Creates directories for HTML coverage and test reports.
+# 3. Invokes pytest via the local virtual environment.
+# 4. Generates terminal output, HTML coverage, JSON coverage, and HTML test reports.
+#
+# Parallel (pytest-xdist) runs occasionally crash *during worker/session
+# teardown* even though every test passed — e.g. the xdist
+# `worker_workerfinished` KeyError or a pytest-html report-write race. pytest
+# signals these runner-internal crashes with exit code 3 (INTERNALERROR),
+# which is distinct from real test failures (1), interruptions (2) and usage
+# errors (4). We therefore retry the suite once on exit code 3 only, so a
+# teardown race no longer flips a green run red, while genuine failures still
+# fail immediately. Stale `.coverage*` data is removed before each attempt so a
+# previously crashed run cannot leave a corrupt data file that reports a false
+# 0% coverage on the next run.
+test:: install ## run all tests
+	@rm -rf _tests
+	@if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
+	  printf "${YELLOW}[WARN] No test files found in ${TESTS_FOLDER}, skipping tests.${RESET}\n"; \
+	  exit 0; \
+	fi; \
+	if [ -d ${SOURCE_FOLDER} ]; then \
+	  set -- -n auto \
+	    --ignore=${TESTS_FOLDER}/benchmarks \
+	    --ignore=${TESTS_FOLDER}/stress \
+	    --cov=${SOURCE_FOLDER} \
+	    --cov-report=term \
+	    --cov-report=html:_tests/html-coverage \
+	    --cov-fail-under=$(COVERAGE_FAIL_UNDER) \
+	    --cov-report=json:_tests/coverage.json \
+	    --cov-report=xml:_tests/coverage.xml \
+	    --html=_tests/html-report/report.html; \
+	else \
+	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, running tests without coverage${RESET}\n"; \
+	  set -- -n auto \
+	    --ignore=${TESTS_FOLDER}/benchmarks \
+	    --ignore=${TESTS_FOLDER}/stress \
+	    --html=_tests/html-report/report.html; \
+	fi; \
+	attempt=1; max_attempts=2; \
+	while :; do \
+	  rm -f .coverage .coverage.* _tests/coverage.xml _tests/coverage.json 2>/dev/null || true; \
+	  mkdir -p _tests/html-coverage _tests/html-report; \
+	  ${UV_BIN} run --with pytest --with pytest-cov --with pytest-xdist --with pytest-html --with pytest-timeout --with pytest-mock pytest "$$@"; status=$$?; \
+	  if [ $$status -ne 3 ]; then exit $$status; fi; \
+	  if [ $$attempt -ge $$max_attempts ]; then \
+	    printf "${RED}[ERROR] pytest reported an internal (teardown) error after %s attempts; failing.${RESET}\n" "$$attempt"; \
+	    exit $$status; \
+	  fi; \
+	  printf "${YELLOW}[WARN] pytest exited 3 (xdist/teardown internal error, all tests may have passed); retrying suite (attempt %s/%s)...${RESET}\n" "$$((attempt + 1))" "$$max_attempts"; \
+	  attempt=$$((attempt + 1)); \
+	done
+
+# The 'typecheck' target runs static type analysis using ty and/or mypy.
+# 1. Builds a list of existing Python source folders to check.
+# 2. Depending on TYPECHECKER (ty|mypy|both, default: both), runs ty,
+#    mypy in strict mode, or both in sequence as a cross-check.
+typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both, default: both)
+	@typecheck_paths=""; \
+	if [ -d "${SOURCE_FOLDER}" ]; then \
+	  typecheck_paths="${SOURCE_FOLDER}"; \
+	fi; \
+	if [ -z "$${typecheck_paths}" ]; then \
+	  printf "${YELLOW}[WARN] No typecheck folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping typecheck${RESET}\n"; \
+	  exit 0; \
+	fi; \
+	case "${TYPECHECKER}" in \
+	  ty) \
+	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} \
+	    ;; \
+	  mypy) \
+	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
+	    ;; \
+	  both) \
+	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
+	    ${UV_BIN} run --with ty ty check $${typecheck_paths} && \
+	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
+	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
+	    ;; \
+	  *) \
+	    printf "${RED}[ERROR] Invalid TYPECHECKER='${TYPECHECKER}' (expected: ty, mypy, or both)${RESET}\n"; \
+	    exit 1 \
+	    ;; \
+	esac
+
+# The 'security' target runs bandit to find common security issues in the
+# Python source folders that exist.
+security: install ## run security scans (bandit)
+	@bandit_paths=""; \
+	if [ -d "${SOURCE_FOLDER}" ]; then \
+	  bandit_paths="${SOURCE_FOLDER}"; \
+	fi; \
+	if [ -n "$${bandit_paths}" ]; then \
+	  printf "${BLUE}[INFO] Running bandit security scan in:$${bandit_paths}${RESET}\n"; \
+	  ${UVX_BIN} bandit -r $${bandit_paths} -ll -q --ini .bandit; \
+	else \
+	  printf "${YELLOW}[WARN] No bandit scan folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping bandit${RESET}\n"; \
+	fi
+
+# The 'docs-coverage' target checks documentation coverage using interrogate.
+# 1. Builds a list of existing Python source folders to check.
+# 2. Runs interrogate with verbose output against those folders.
+docs-coverage: install ## check documentation coverage with interrogate
+	@docstring_paths=""; \
+	if [ -d "${SOURCE_FOLDER}" ]; then \
+	  docstring_paths="${SOURCE_FOLDER}"; \
+	fi; \
+	if [ -d "tests" ]; then \
+	  docstring_paths="$${docstring_paths} tests"; \
+	fi; \
+	if [ -d ".rhiza/tests" ]; then \
+	  docstring_paths="$${docstring_paths} .rhiza/tests"; \
+	fi; \
+	if [ -n "$${docstring_paths}" ]; then \
+	  printf "${BLUE}[INFO] Checking documentation coverage in:$${docstring_paths}${RESET}\n"; \
+	  ${UV_BIN} run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic $${docstring_paths}; \
+	else \
+	  printf "${YELLOW}[WARN] No docs-coverage folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping docs-coverage${RESET}\n"; \
+	fi
+
+test-pyproject: install ## run pyproject.toml structure tests
+	@${UV_BIN} run --with pytest pytest .rhiza/tests/test_pyproject.py \
+		-v \
+		--tb=long \
+		--showlocals \
+		-rA \
+		--durations=0 \
+		--no-header

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -1,40 +1,36 @@
 ## .rhiza/make.d/quality.mk - Quality and Formatting
-# This file provides targets for code quality checks, linting, and formatting.
-
-# Configurable list of licenses that fail the compliance scan (semicolon-separated)
-LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
+# The language-neutral gates: pre-commit, the TODO sweep, semgrep, and the runner for
+# the template's own test suite. Everything that needs to know how the project declares
+# its dependencies — `deptry`, the licence-compliance scan — and the `all` aggregate that
+# names the per-language gates live in the language layer (python.mk, from the
+# python-core bundle).
 
 # Declare phony targets (they don't produce files)
-.PHONY: all deptry fmt license todos semgrep
+.PHONY: fmt todos semgrep rhiza-test
 
 ##@ Quality and Formatting
-all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
-
-# deptry scans one or more folders for dependency issues. Each feature bundle
-# contributes the folders it owns to DEPTRY_FOLDERS (and any per-folder ignores
-# to DEPTRY_IGNORE), so this core target never needs to know which bundles are
-# present. Core itself contributes SOURCE_FOLDER when it exists; see e.g.
-# marimo.mk for a bundle that appends its own folder. Rhiza's own test folder
-# (.rhiza/tests) is deliberately excluded: its tooling is provisioned on the fly
-# via `uv run --with` in the individual targets, not declared in the project's
-# pyproject, so deptry (which validates against pyproject) would only emit noise
-# for it.
-DEPTRY_FOLDERS ?=
-DEPTRY_IGNORE ?=
-ifneq ($(wildcard $(SOURCE_FOLDER)),)
-DEPTRY_FOLDERS += $(SOURCE_FOLDER)
-endif
-
-deptry: install-uv ## Run deptry over the folders contributed by each bundle
-	@if [ -n "$(strip $(DEPTRY_FOLDERS))" ]; then \
-		printf "${BLUE}[INFO] Running deptry on:${RESET} $(strip $(DEPTRY_FOLDERS))\n"; \
-		$(UVX_BIN) -p ${PYTHON_VERSION} deptry $(strip $(DEPTRY_FOLDERS) $(DEPTRY_IGNORE)); \
-	else \
-		printf "${YELLOW}[WARN] no deptry folders found, skipping.${RESET}\n"; \
-	fi
-
+# prek rather than pre-commit: a Rust reimplementation that reads the same
+# `.pre-commit-config.yaml` and needs no Python of its own. Two consequences, one
+# gained and one that has to be asked for.
+#
+# Gained: the `-p ${PYTHON_VERSION}` this recipe used to carry is gone. That flag
+# existed because `uvx pre-commit` had to choose an interpreter to run pre-commit
+# *itself* on, and a Rust or Go project ships no `.python-version` — so the whole
+# language-neutral half of the template rested on rhiza.mk's fallback resolving to
+# something real. prek is a binary and provisions each hook's toolchain itself, so the
+# coupling is removed rather than merely satisfied.
+#
+# Asked for: `--config`. By default prek treats every directory below the root that
+# holds a `.pre-commit-config.yaml` as a separate *project* and runs each one's hooks —
+# useful in a monorepo, surprising anywhere else, and wrong in rhiza's own repo, where
+# `bundles/{python,rust,go}-core` each ship one as template content. (go-core's hooks
+# then run `go vet ./...` in a directory with no `go.mod` and fail.) Naming the config
+# explicitly disables that discovery, so `make fmt` means exactly what it meant under
+# pre-commit: this repo's config, once. A consumer who wants the monorepo behaviour
+# drops the flag. `.prekignore` is documented for the same job but is not honoured by
+# prek 0.4.12, so it is not what this relies on.
 fmt: install-uv ## check the pre-commit hooks and the linting
-	@${UVX_BIN} -p ${PYTHON_VERSION} pre-commit run --all-files
+	@${UVX_BIN} prek run --all-files --config .pre-commit-config.yaml
 
 todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 	@printf "${BLUE}[INFO] Searching for TODO, FIXME, and HACK comments...${RESET}\n"
@@ -60,6 +56,24 @@ semgrep: install ## run Semgrep static analysis
 		printf "${YELLOW}[WARN] SOURCE_FOLDER '${SOURCE_FOLDER}' not found, skipping semgrep.${RESET}\n"; \
 	fi
 
-license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
-	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"
-	@${UV_BIN} run --with pip-licenses pip-licenses --fail-on="${LICENSE_FAIL_ON}"
+# Owned by core, not by a language layer, because nothing about it is language-specific:
+# `.rhiza/tests` validates the *template* — READMEs, release config, YAML — and runs
+# under pytest whatever the project is written in. `uv` lives in core for the same
+# reason. Each layer contributes its own modules to the suite (test_pyproject.py,
+# test_cargo_toml.py, test_go_module.py) while the runner stays here, so the recipe
+# exists once rather than identically in all three (#1471).
+#
+# `install` is a deliberate exception to core's rule of never naming a layer-owned
+# target. It is a *prerequisite* here, not a definition, and the suite needs it: the
+# shipped test_docstrings.py imports the project's own packages to run their doctests,
+# which requires the dependencies installed. Make resolves it because every fragment is
+# included into one namespace, and every profile selects exactly one language layer —
+# `test_a_profile_never_selects_two_bundles_from_one_layer` and
+# `test_every_profile_selects_a_language_layer` bracket that from both sides. A
+# core-only tree is not a shipped configuration; there, this fails naming `install`.
+rhiza-test: install ## run rhiza's own tests (if any)
+	@if [ -d ".rhiza/tests" ]; then \
+		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
+	else \
+		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
+	fi

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -1,128 +1,26 @@
-## Makefile.tests - Testing and benchmarking targets
+## .rhiza/make.d/test.mk - optional Python testing extras (bundle: tests)
 # This file is included by the main Makefile.
-# It provides targets for running the test suite with coverage and
-# executing performance benchmarks.
+#
+# The gates the language contract names — `test`, `typecheck`, `security`,
+# `docs-coverage` — moved into `python.mk` in #1475, because `python.mk`'s own `all`
+# named them while this bundle owned them: a project syncing `core + python-core`
+# without `tests` got an `all` that could not run. The Rust and Go layers never had
+# that split, and now neither does Python.
+#
+# What is left here is what genuinely *is* optional — four gates no layer's `all`
+# depends on, each of which needs its own tool and its own folder convention:
+# benchmarks, Hypothesis property tests, stress/load tests and mutation testing.
+# Keeping them out of the layer is what lets a project take the Python gate set
+# without also declaring an opinion on mutation testing.
+#
+# `TESTS_FOLDER`, and the shared pytest config in `pytest.ini`, come from
+# `python.mk` / `python-core`. This bundle requires `python-core`, so both are always
+# present alongside it.
 
 # Declare phony targets (they don't produce files)
-.PHONY: test benchmark typecheck security docs-coverage hypothesis-test stress test-pyproject mutation
+.PHONY: benchmark hypothesis-test stress mutation
 
-# Default directory for tests
-TESTS_FOLDER := tests
-
-# Minimum coverage percent for tests to pass
-# (Can be overridden in local.mk or via environment variable)
-COVERAGE_FAIL_UNDER ?= 90
-
-# Which static type checker(s) the 'typecheck' target runs: ty, mypy, or both.
-# Running both is the default for backward compatibility, but ty and mypy
-# occasionally disagree (e.g. one accepts a suppression the other still flags),
-# forcing duplicate `# type: ignore` / `# ty: ignore` comments. Set this to
-# 'ty' or 'mypy' in local.mk or .rhiza/.env to run a single checker instead.
-TYPECHECKER ?= both
-
-##@ Development and Testing
-
-# The 'test' target runs the complete test suite.
-# 1. Cleans up any previous test results in _tests/ and stale coverage data.
-# 2. Creates directories for HTML coverage and test reports.
-# 3. Invokes pytest via the local virtual environment.
-# 4. Generates terminal output, HTML coverage, JSON coverage, and HTML test reports.
-#
-# Parallel (pytest-xdist) runs occasionally crash *during worker/session
-# teardown* even though every test passed — e.g. the xdist
-# `worker_workerfinished` KeyError or a pytest-html report-write race. pytest
-# signals these runner-internal crashes with exit code 3 (INTERNALERROR),
-# which is distinct from real test failures (1), interruptions (2) and usage
-# errors (4). We therefore retry the suite once on exit code 3 only, so a
-# teardown race no longer flips a green run red, while genuine failures still
-# fail immediately. Stale `.coverage*` data is removed before each attempt so a
-# previously crashed run cannot leave a corrupt data file that reports a false
-# 0% coverage on the next run.
-test:: install ## run all tests
-	@rm -rf _tests
-	@if [ -z "$$(find ${TESTS_FOLDER} -name 'test_*.py' -o -name '*_test.py' 2>/dev/null)" ]; then \
-	  printf "${YELLOW}[WARN] No test files found in ${TESTS_FOLDER}, skipping tests.${RESET}\n"; \
-	  exit 0; \
-	fi; \
-	if [ -d ${SOURCE_FOLDER} ]; then \
-	  set -- -n auto \
-	    --ignore=${TESTS_FOLDER}/benchmarks \
-	    --ignore=${TESTS_FOLDER}/stress \
-	    --cov=${SOURCE_FOLDER} \
-	    --cov-report=term \
-	    --cov-report=html:_tests/html-coverage \
-	    --cov-fail-under=$(COVERAGE_FAIL_UNDER) \
-	    --cov-report=json:_tests/coverage.json \
-	    --cov-report=xml:_tests/coverage.xml \
-	    --html=_tests/html-report/report.html; \
-	else \
-	  printf "${YELLOW}[WARN] Source folder ${SOURCE_FOLDER} not found, running tests without coverage${RESET}\n"; \
-	  set -- -n auto \
-	    --ignore=${TESTS_FOLDER}/benchmarks \
-	    --ignore=${TESTS_FOLDER}/stress \
-	    --html=_tests/html-report/report.html; \
-	fi; \
-	attempt=1; max_attempts=2; \
-	while :; do \
-	  rm -f .coverage .coverage.* _tests/coverage.xml _tests/coverage.json 2>/dev/null || true; \
-	  mkdir -p _tests/html-coverage _tests/html-report; \
-	  ${UV_BIN} run --with pytest --with pytest-cov --with pytest-xdist --with pytest-html --with pytest-timeout --with pytest-mock pytest "$$@"; status=$$?; \
-	  if [ $$status -ne 3 ]; then exit $$status; fi; \
-	  if [ $$attempt -ge $$max_attempts ]; then \
-	    printf "${RED}[ERROR] pytest reported an internal (teardown) error after %s attempts; failing.${RESET}\n" "$$attempt"; \
-	    exit $$status; \
-	  fi; \
-	  printf "${YELLOW}[WARN] pytest exited 3 (xdist/teardown internal error, all tests may have passed); retrying suite (attempt %s/%s)...${RESET}\n" "$$((attempt + 1))" "$$max_attempts"; \
-	  attempt=$$((attempt + 1)); \
-	done
-
-# The 'typecheck' target runs static type analysis using ty and/or mypy.
-# 1. Builds a list of existing Python source folders to check.
-# 2. Depending on TYPECHECKER (ty|mypy|both, default: both), runs ty,
-#    mypy in strict mode, or both in sequence as a cross-check.
-typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both, default: both)
-	@typecheck_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  typecheck_paths="${SOURCE_FOLDER}"; \
-	fi; \
-	if [ -z "$${typecheck_paths}" ]; then \
-	  printf "${YELLOW}[WARN] No typecheck folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping typecheck${RESET}\n"; \
-	  exit 0; \
-	fi; \
-	case "${TYPECHECKER}" in \
-	  ty) \
-	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run --with ty ty check $${typecheck_paths} \
-	    ;; \
-	  mypy) \
-	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
-	    ;; \
-	  both) \
-	    printf "${BLUE}[INFO] Running ty type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run --with ty ty check $${typecheck_paths} && \
-	    printf "${BLUE}[INFO] Running mypy strict type checking in:$${typecheck_paths}${RESET}\n"; \
-	    ${UV_BIN} run --with mypy mypy --strict $${typecheck_paths} \
-	    ;; \
-	  *) \
-	    printf "${RED}[ERROR] Invalid TYPECHECKER='${TYPECHECKER}' (expected: ty, mypy, or both)${RESET}\n"; \
-	    exit 1 \
-	    ;; \
-	esac
-
-# The 'security' target runs bandit to find common security issues in the
-# Python source folders that exist.
-security: install ## run security scans (bandit)
-	@bandit_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  bandit_paths="${SOURCE_FOLDER}"; \
-	fi; \
-	if [ -n "$${bandit_paths}" ]; then \
-	  printf "${BLUE}[INFO] Running bandit security scan in:$${bandit_paths}${RESET}\n"; \
-	  ${UVX_BIN} bandit -r $${bandit_paths} -ll -q --ini .bandit; \
-	else \
-	  printf "${YELLOW}[WARN] No bandit scan folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping bandit${RESET}\n"; \
-	fi
+##@ Development and Testing (extras)
 
 # The 'benchmark' target runs performance benchmarks using pytest-benchmark.
 # 1. Installs benchmarking dependencies (pytest-benchmark, pygal).
@@ -138,27 +36,6 @@ benchmark:: install ## run performance benchmarks
 			--benchmark-json=_tests/benchmarks/results.json; \
 	else \
 	  printf "${YELLOW}[WARN] Benchmarks folder not found, skipping benchmarks${RESET}\n"; \
-	fi
-
-# The 'docs-coverage' target checks documentation coverage using interrogate.
-# 1. Builds a list of existing Python source folders to check.
-# 2. Runs interrogate with verbose output against those folders.
-docs-coverage: install ## check documentation coverage with interrogate
-	@docstring_paths=""; \
-	if [ -d "${SOURCE_FOLDER}" ]; then \
-	  docstring_paths="${SOURCE_FOLDER}"; \
-	fi; \
-	if [ -d "tests" ]; then \
-	  docstring_paths="$${docstring_paths} tests"; \
-	fi; \
-	if [ -d ".rhiza/tests" ]; then \
-	  docstring_paths="$${docstring_paths} .rhiza/tests"; \
-	fi; \
-	if [ -n "$${docstring_paths}" ]; then \
-	  printf "${BLUE}[INFO] Checking documentation coverage in:$${docstring_paths}${RESET}\n"; \
-	  ${UV_BIN} run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic $${docstring_paths}; \
-	else \
-	  printf "${YELLOW}[WARN] No docs-coverage folders found (SOURCE_FOLDER='${SOURCE_FOLDER}'), skipping docs-coverage${RESET}\n"; \
 	fi
 
 # The 'hypothesis-test' target runs property-based tests using Hypothesis.
@@ -220,12 +97,3 @@ mutation: install ## run mutation tests with mutmut
 	mv html _tests/mutation/html || exit $$?; \
 	${UV_BIN} run --with mutmut mutmut results || exit $$?; \
 	exit $$run_status
-
-test-pyproject: install ## run pyproject.toml structure tests
-	@${UV_BIN} run --with pytest pytest .rhiza/tests/test_pyproject.py \
-		-v \
-		--tb=long \
-		--showlocals \
-		-rA \
-		--durations=0 \
-		--no-header

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -62,18 +62,28 @@ RESET := \033[0m
 	version-matrix \
 	ci-os-matrix
 
+# ---------------------------------------------------------------------------
+# uv as a *tool runner*, not as a language choice.
+#
+# Rhiza reaches for uvx to run pre-commit, mkdocs, semgrep and the rest whatever
+# the project is written in, so provisioning it belongs to core. What is Python-
+# specific — the project virtualenv, the `install` target that syncs it, and the
+# project's own interpreter version — lives in the language layer
+# (`bundles/python-core`), which ships `.rhiza/make.d/python.mk`.
+# ---------------------------------------------------------------------------
+
 # we need absolute paths!
 INSTALL_DIR ?= $(abspath ./bin)
 UV_BIN ?= $(shell command -v uv 2>/dev/null || echo ${INSTALL_DIR}/uv)
 UVX_BIN ?= $(shell command -v uvx 2>/dev/null || echo ${INSTALL_DIR}/uvx)
-VENV ?= .venv
 
-# Read Python version from .python-version (single source of truth)
+# The interpreter rhiza's own tooling runs on. A Python project overrides this
+# from `.python-version` (see python.mk, which makes it the project's version
+# too); anywhere else the fallback is simply the Python uvx provisions.
 PYTHON_VERSION ?= $(strip $(shell cat .python-version 2>/dev/null || echo "3.13"))
 export PYTHON_VERSION
 
 export UV_NO_MODIFY_PATH := 1
-export UV_VENV_CLEAR := 1
 
 # Unset VIRTUAL_ENV to prevent uv from warning about path mismatches
 # when a virtual environment is already activated in the shell
@@ -123,20 +133,13 @@ print-logo:
 	@printf "${BLUE}$$RHIZA_LOGO${RESET}\n"
 
 
-rhiza-test: install ## run rhiza's own tests (if any)
-	@if [ -d ".rhiza/tests" ]; then \
-		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
-	else \
-		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
-	fi
-
 ##@ Meta
 
 help: print-logo ## Display this help message
 	+@printf "$(BOLD)Usage:$(RESET)\n"
 	+@printf "  make $(BLUE)<target>$(RESET)\n\n"
 	+@printf "$(BOLD)Targets:$(RESET)\n"
-	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	+@printf "\n"
 
 ci-os-matrix: ## Emit GitHub CI OSes (RHIZA_CI_OS_MATRIX as JSON array, default ["ubuntu-latest"])

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: e5d7005e2d9fc3d5a23b96d13b203b4f2afe3cce
+sha: 996d5df684d8967907d883e43e0d28376b0ac140
 repo: jebel-quant/rhiza
 host: github
-ref: v1.2.5
+ref: v1.3.2
 include: []
 exclude: []
 templates:
@@ -36,7 +36,6 @@ files:
 - .gitignore
 - .pre-commit-config.yaml
 - .python-version
-- .rhiza/.cfg.toml
 - .rhiza/.env
 - .rhiza/.gitignore
 - .rhiza/CODE_OF_CONDUCT.md
@@ -53,6 +52,7 @@ files:
 - .rhiza/make.d/doctor.mk
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
+- .rhiza/make.d/python.mk
 - .rhiza/make.d/quality.mk
 - .rhiza/make.d/test.mk
 - .rhiza/rhiza.mk
@@ -61,7 +61,9 @@ files:
 - .rhiza/tests/conftest.py
 - .rhiza/tests/test_docstrings.py
 - .rhiza/tests/test_pyproject.py
+- .rhiza/tests/test_readme.py
 - .rhiza/tests/test_readme_validation.py
+- .rhiza/tests/test_release_tags.py
 - LICENSE
 - Makefile
 - SECURITY.md
@@ -73,5 +75,6 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-07-30T10:38:29Z'
+- tests/test_rhiza_packaging.py
+synced_at: '2026-08-04T17:53:18Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: jebel-quant/rhiza
-template-branch: "v1.2.5"
+template-branch: "v1.3.2"
 
 profiles:
   - github-project

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
-template-repository: jebel-quant/rhiza
-template-branch: "v1.3.2"
+repository: "jebel-quant/rhiza"
+ref: "v1.3.2"
 
 profiles:
   - github-project

--- a/.rhiza/tests/README.md
+++ b/.rhiza/tests/README.md
@@ -1,9 +1,9 @@
 # Rhiza Test Suite (`.rhiza/tests/`)
 
 This directory is **synced from [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza)**
-via the `tests` bundle and runs in your project with `make rhiza-test`. Its job is to
-validate the parts of *your* repository that Rhiza cares about — the metadata, docs, and
-docstrings that vary per project — using the shared fixtures and helpers below.
+and runs in your project with `make rhiza-test`. Its job is to validate the parts of *your*
+repository that Rhiza cares about — the metadata, release config, docs and docstrings that
+vary per project — using the shared fixtures below.
 
 > Tests that only exercise Rhiza's *own* template files (Makefile targets, workflow stubs,
 > the project skeleton) live in Rhiza's mother-repo `tests/` suite and are **not** synced
@@ -12,19 +12,30 @@ docstrings that vary per project — using the shared fixtures and helpers below
 
 ## Layout
 
-The suite is flat — one file per concern:
+The suite is flat — one file per concern — but **which files you get depends on the
+bundles you sync**. Each is owned by whichever bundle the assertion belongs to, so a Rust
+project gets the Rust manifest checks and none of the Python ones:
 
-- `test_pyproject.py` — validates `pyproject.toml` structure and required fields
-- `test_readme_validation.py` — executes/syntax-checks `README.md` code blocks (see below)
-- `test_docstrings.py` — runs doctests across the modules in your source folder
-- `conftest.py` — shared fixtures (`root`, `logger`)
+| file | owned by | checks |
+| --- | --- | --- |
+| `conftest.py` | `core` | shared fixtures (`root`, `logger`, `latest_tag`) |
+| `test_release_tags.py` | `core` | the newest tag is reachable from a branch |
+| `test_readme.py` | `core` | README exists; every `bash` fence parses |
+| `test_pyproject.py` | `python-core` | `pyproject.toml` structure, and its `[tool.bumpversion]` block |
+| `test_docstrings.py` | `python-core` | doctests across the modules in your source folder |
+| `test_readme_validation.py` | `tests` | executes `python` fences and diffs them against `result` (see below) |
+| `test_cargo_toml.py` | `rust-core` | `Cargo.toml` structure and the `.bumpversion.toml` wiring |
+| `test_go_module.py` | `go-core` | `go.mod`, the `Version` constant, and the same wiring |
+
+Every profile pairs `core` with exactly one language layer, so `conftest.py` is always
+present alongside whichever layer's modules arrived.
 
 ### Skipping README code blocks with `+RHIZA_SKIP`
 
-By default, every `python` and `bash` code block in `README.md` is executed or
-syntax-checked by `test_readme_validation.py`. To mark a block as intentionally
-non-runnable (e.g. illustrative snippets or environment-specific commands), add
-`+RHIZA_SKIP` to the opening fence line:
+By default, every `bash` fence in `README.md` is syntax-checked (`test_readme.py`, any
+language) and every `python` fence is executed (`test_readme_validation.py`, Python
+projects). To mark a block as intentionally non-runnable — an illustrative snippet, an
+environment-specific command — add `+RHIZA_SKIP` to the opening fence line:
 
 ~~~markdown
 ```python +RHIZA_SKIP

--- a/.rhiza/tests/conftest.py
+++ b/.rhiza/tests/conftest.py
@@ -3,7 +3,14 @@
 This file and its associated tests flow down via a SYNC action from the jebel-quant/rhiza repository
 (https://github.com/jebel-quant/rhiza).
 
-Provides shared session-scoped fixtures (``root`` and ``logger``) used across the test modules.
+Provides shared session-scoped fixtures (``root``, ``logger`` and ``latest_tag``) used
+across the test modules.
+
+Owned by ``core`` rather than by a language layer: the fixtures resolve paths and read
+git, neither of which depends on what the project is written in. That is what lets the
+Rust and Go layers ship their own ``.rhiza/tests`` modules without shipping a conftest
+each — every profile pairs ``core`` with exactly one language layer, so this file is
+always present alongside them.
 
 Security Notes:
 - S101 (assert usage): Asserts are appropriate in test code for validating conditions
@@ -11,8 +18,12 @@ Security Notes:
 
 import logging
 import pathlib
+import shutil
+import subprocess  # nosec B404
 
 import pytest
+
+_GIT = shutil.which("git") or "/usr/bin/git"
 
 
 @pytest.fixture(scope="session")
@@ -32,3 +43,30 @@ def logger():
         logging.Logger: Logger configured for the test session.
     """
     return logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def latest_tag(root):
+    """Return the newest ``vX.Y.Z`` git tag, skipping when the repo has none.
+
+    Shared rather than per-module because each language layer asserts the same thing
+    against a different file — ``[project].version``, ``[package].version``, or Go's
+    ``Version`` constant — and because every layer's release config derives its current
+    version from this tag.
+
+    Args:
+        root: Repository root, from the ``root`` fixture.
+
+    Returns:
+        str: The highest version tag, e.g. ``v1.3.1``.
+    """
+    result = subprocess.run(  # nosec B603
+        [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not tags:
+        pytest.skip("No version tags found in repository")
+    return tags[0]

--- a/.rhiza/tests/test_pyproject.py
+++ b/.rhiza/tests/test_pyproject.py
@@ -12,24 +12,52 @@ Validates that pyproject.toml:
 - provides [project.urls] with Homepage and Repository
 - includes at least one Python version classifier
 - declares a [dependency-groups] test group containing pytest
+- carries a [tool.bumpversion] table bump-my-version can actually discover
 - version matches the latest git tag (vX.Y.Z → X.Y.Z)
+
+Reachability of that tag lives in ``test_release_tags.py``, shipped by ``core``: the
+invariant holds for every language layer, not just this one.
 """
 
 from __future__ import annotations
 
 import re
-import shutil
-import subprocess  # nosec B404
 import tomllib
 from pathlib import Path
 
 import pytest
 from packaging.version import Version
 
-_GIT = shutil.which("git") or "/usr/bin/git"
-
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
 _REQUIRED_PROJECT_FIELDS = ("name", "version", "description", "readme", "requires-python", "license", "authors")
+
+# The only filenames bump-my-version auto-discovers. Anything else — including the
+# `.rhiza/.cfg.toml` older template versions shipped — is read solely when passed
+# with --config-file, which nothing in this template does.
+_DISCOVERABLE_CONFIGS = (".bumpversion.toml", ".bumpversion.cfg", "setup.cfg", "pyproject.toml")
+
+
+def _has_bumpversion_section(path: Path) -> bool:
+    """Report whether a config file carries a bumpversion section at all.
+
+    Args:
+        path: Candidate config file; a missing or malformed file counts as absent.
+
+    Returns:
+        True when the file declares ``[tool.bumpversion]`` (TOML) or ``[bumpversion]``
+        (INI). ``.bumpversion.toml`` nests the table under ``[tool]`` just as
+        pyproject.toml does.
+    """
+    if not path.is_file():
+        return False
+    if path.suffix == ".cfg":
+        return "[bumpversion]" in path.read_text(encoding="utf-8")
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except tomllib.TOMLDecodeError:
+        return False
+    return isinstance(data.get("tool", {}).get("bumpversion"), dict)
 
 
 @pytest.fixture(scope="module")
@@ -170,7 +198,17 @@ class TestProjectClassifiers:
 
 
 class TestDependencyGroups:
-    """Tests for [dependency-groups] — ensures required groups are declared."""
+    """Tests for [dependency-groups] — ensures required groups are declared.
+
+    Only ``test`` is required, and only because ``make test`` has to have somewhere to
+    find pytest. There was a ``test_lint_group_present`` here until #1484, and it is
+    worth saying why it went: rhiza provisions every linter through prek/uvx, so the
+    group it demanded had nothing legitimate to hold, and the mother repo satisfied it
+    with a literal ``lint = []``. A required-group check that the reference
+    implementation can only pass by declaring an empty list is testing a convention
+    rather than a working project, so a project may still declare ``lint`` — nothing
+    reads it.
+    """
 
     @pytest.fixture
     def dependency_groups(self, pyproject: dict) -> dict:
@@ -192,22 +230,105 @@ class TestDependencyGroups:
         )
 
 
-class TestGitTagVersion:
-    """Tests for harmony between the latest git tag and pyproject.toml version."""
+class TestBumpversionConfigIsDiscoverable:
+    """The release flow must find a version config, not silently invent one (#1453).
+
+    bump-my-version searches four filenames and stops. When it finds none it does
+    **not** fail — it falls back to ``git describe`` and reports the last reachable
+    tag as the current version. Release tooling then computes bump candidates from
+    that number rather than the project's, which is how a repo at 0.7.0 with a
+    newest reachable tag of v0.6.4 gets offered "minor → v0.7.0", a version it has
+    already published.
+
+    Once a ``[tool.bumpversion]`` table exists in pyproject.toml, bump-my-version
+    reads and rewrites PEP 621 ``[project].version`` natively, so the minimum
+    workable config is three lines and duplicates the version string nowhere::
+
+        [tool.bumpversion]
+        allow_dirty = false
+        # /rhiza:release commits and tags itself so the changelog lands in the
+        # bump commit.
+        commit = false
+        tag = false
+
+    Add a ``[[tool.bumpversion.files]]`` entry per *additional* location (a plugin
+    manifest, a self-referencing CI stub pin) — never for ``[project].version``
+    itself.
+    """
 
     @pytest.fixture
-    def latest_tag(self, root: Path) -> str:
-        """Return the latest semver git tag, or skip if none exist."""
-        result = subprocess.run(  # nosec B603
-            [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],
-            capture_output=True,
-            text=True,
-            cwd=root,
+    def declared_version(self, project: dict) -> str:
+        """The statically declared project version, or skip when it is dynamic."""
+        version = project.get("version")
+        if not isinstance(version, str):
+            pytest.skip("[project].version is dynamic — no static location to bump")
+        return version
+
+    def test_a_discoverable_config_exists(self, root: Path, pyproject: dict, declared_version: str) -> None:
+        """A bumpversion section must live in a file bump-my-version actually reads."""
+        found = [name for name in _DISCOVERABLE_CONFIGS if _has_bumpversion_section(root / name)]
+        hint = ""
+        if (root / ".rhiza" / ".cfg.toml").is_file():
+            hint = (
+                " A leftover .rhiza/.cfg.toml is present: that path is never auto-discovered "
+                "(it predates the fix for issue #1453) and can be deleted."
+            )
+        assert found, (
+            f"pyproject.toml declares version {declared_version!r} but no bumpversion config "
+            f"was found in any file bump-my-version searches ({', '.join(_DISCOVERABLE_CONFIGS)}). "
+            f"It will silently fall back to `git describe`, so a release can be cut at a version "
+            f"that already exists. Add a [tool.bumpversion] table to pyproject.toml.{hint}"
         )
-        tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
-        if not tags:
-            pytest.skip("No version tags found in repository")
-        return tags[0]
+
+    def test_pyproject_is_the_config_that_wins(self, root: Path, declared_version: str) -> None:
+        """No earlier-searched file may shadow pyproject.toml's table.
+
+        Search order is significant: a ``.bumpversion.toml`` beats pyproject.toml and
+        takes ``[project].version`` out of the picture, so the two version numbers can
+        then drift apart unnoticed. A Python project keeps its version in one place.
+        """
+        shadowing = [
+            name for name in _DISCOVERABLE_CONFIGS if name != "pyproject.toml" and _has_bumpversion_section(root / name)
+        ]
+        assert not shadowing, (
+            f"{shadowing} is searched before pyproject.toml and would shadow its "
+            f"[tool.bumpversion] table, detaching the bump from [project].version "
+            f"({declared_version!r})"
+        )
+
+    def test_config_does_not_duplicate_the_version(self, pyproject: dict, declared_version: str) -> None:
+        """``current_version`` is redundant in pyproject.toml, and drifts once stale."""
+        section = pyproject.get("tool", {}).get("bumpversion")
+        if not isinstance(section, dict):
+            pytest.skip("no [tool.bumpversion] table — reported by test_a_discoverable_config_exists")
+        declared_in_config = section.get("current_version")
+        assert declared_in_config in (None, declared_version), (
+            f"[tool.bumpversion].current_version is {declared_in_config!r} but "
+            f"[project].version is {declared_version!r}; bumping from the stale value cannot "
+            f"match the version in the file. Drop current_version — bump-my-version reads "
+            f"[project].version natively."
+        )
+
+    def test_the_release_flow_owns_the_commit_and_the_tag(self, pyproject: dict) -> None:
+        """``/rhiza:release`` folds the changelog into the bump commit and tags it itself."""
+        section = pyproject.get("tool", {}).get("bumpversion")
+        if not isinstance(section, dict):
+            pytest.skip("no [tool.bumpversion] table — reported by test_a_discoverable_config_exists")
+        for key in ("commit", "tag"):
+            assert section.get(key, False) is False, (
+                f"[tool.bumpversion].{key} must be false: the release flow commits and tags "
+                f"itself so the changelog lands in the bump commit, and a bare "
+                f"`bump-my-version bump` would otherwise add a second commit and a duplicate tag"
+            )
+
+
+class TestGitTagVersion:
+    """Tests for harmony between the latest git tag and pyproject.toml version.
+
+    Reachability of that tag is asserted by ``test_release_tags.py``, which ``core``
+    ships: the invariant is about git rather than about Python, and all three language
+    layers need it.
+    """
 
     def test_latest_tag_matches_pyproject_version(self, latest_tag: str, project: dict) -> None:
         """The latest git tag (vX.Y.Z) must match [project].version in pyproject.toml."""

--- a/.rhiza/tests/test_readme.py
+++ b/.rhiza/tests/test_readme.py
@@ -1,0 +1,140 @@
+"""Tests for the README that hold whatever the project is written in.
+
+This file and its associated tests flow down via a SYNC action from the
+jebel-quant/rhiza repository (https://github.com/jebel-quant/rhiza).
+
+Owned by ``core`` because none of it is language-specific: every synced README documents
+its gates in ``bash`` fences — ``make install``, ``make test``, ``make all`` — and a
+fence with a syntax error is broken the same way in a Rust, Go or Python project. Before
+this split (#1472) all of it lived in the ``tests`` bundle, which requires
+``python-core``, so a Rust or Go repo had no README coverage at all.
+
+The Python-block half stays behind in ``tests`` as ``test_readme_validation.py``: it
+executes ``python`` fences and diffs them against a ``result`` block, which only means
+something where the project *is* Python.
+
+Note the split of labour with the fence flags: ``SKIP_FLAG`` and ``_should_skip`` are
+duplicated across the two modules rather than shared. Bundles are copied
+independently — a Rust project receives this file and not the other — so a shared helper
+would need a third home that both bundles ship, which is a worse trade for four lines.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404
+from pathlib import Path
+
+import pytest
+
+# Bash code blocks — captures optional flags (e.g. "+RHIZA_SKIP") and the code body.
+BASH_BLOCK = re.compile(r"```bash([^\n]*)\n(.*?)```", re.DOTALL)
+
+# Bash executable used for syntax checking; `bash -n` parses without executing.
+BASH = "bash"
+
+# Flag marking a fence as intentionally excluded. Usage: add it after the language
+# identifier on the opening fence line, e.g. ```bash +RHIZA_SKIP
+SKIP_FLAG = "+RHIZA_SKIP"
+
+# Box-drawing characters mean the fence is a directory tree, not runnable shell.
+_TREE_MARKERS = ("├──", "└──", "│")
+
+
+def _should_skip(flags: str) -> bool:
+    """Return True if the fence flags string contains the +RHIZA_SKIP marker.
+
+    Args:
+        flags: Text following the language identifier on the opening fence line.
+
+    Returns:
+        True when the block is intentionally excluded.
+    """
+    return SKIP_FLAG in flags
+
+
+class TestReadmeExists:
+    """The README has to be there and be readable before anything else applies."""
+
+    def test_readme_file_exists_at_root(self, root: Path) -> None:
+        """README.md should exist at repository root."""
+        readme = root / "README.md"
+        assert readme.exists(), "README.md not found at project root"
+        assert readme.is_file(), "README.md is not a regular file"
+
+    def test_readme_is_readable(self, root: Path) -> None:
+        """README.md should be readable with UTF-8 encoding and non-empty."""
+        content = (root / "README.md").read_text(encoding="utf-8")
+        assert content.strip(), "README.md is empty"
+
+
+class TestReadmeBashFragments:
+    """Bash fences must parse, in any language's project.
+
+    Only ``bash -n`` — the blocks are parsed, never executed. A README's shell examples
+    are usually destructive-adjacent (`make clean`, `git push`) and running them is not
+    what this is for; a fence that cannot even parse is a documentation bug regardless.
+    """
+
+    def test_bash_blocks_basic_syntax(self, root: Path, logger) -> None:
+        """Every non-skipped bash block should parse under `bash -n`."""
+        content = (root / "README.md").read_text(encoding="utf-8")
+        bash_blocks = BASH_BLOCK.findall(content)
+
+        logger.info("Found %d bash code block(s) in README", len(bash_blocks))
+
+        for i, (flags, code) in enumerate(bash_blocks):
+            if _should_skip(flags):
+                logger.info("Skipping bash block %d (%s flag)", i, SKIP_FLAG)
+                continue
+
+            if any(marker in code for marker in _TREE_MARKERS):
+                logger.info("Skipping bash block %d (directory tree representation)", i)
+                continue
+
+            # A block that is only comments has nothing to parse and no way to be wrong.
+            lines = [line.strip() for line in code.split("\n") if line.strip()]
+            if not [line for line in lines if not line.startswith("#")]:
+                logger.info("Skipping bash block %d (only comments)", i)
+                continue
+
+            logger.debug("Checking bash block %d:\n%s", i, code)
+
+            result = subprocess.run(  # nosec B603 B607 - `bash -n` parses without executing
+                [BASH, "-n"],
+                input=code,
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                pytest.fail(f"Bash block {i} has syntax errors:\nCode:\n{code}\nError:\n{result.stderr}")
+
+
+class TestSkipFlag:
+    """Tests for the +RHIZA_SKIP flag that excludes an individual fence."""
+
+    def test_should_skip_returns_true_for_skip_flag(self) -> None:
+        """+RHIZA_SKIP in flags string should cause _should_skip to return True."""
+        assert _should_skip(" +RHIZA_SKIP") is True
+        assert _should_skip("+RHIZA_SKIP") is True
+        assert _should_skip(" +RHIZA_SKIP other-flag") is True
+
+    def test_should_skip_returns_false_without_flag(self) -> None:
+        """Absence of +RHIZA_SKIP should cause _should_skip to return False."""
+        assert _should_skip("") is False
+        assert _should_skip(" ") is False
+        assert _should_skip("other-flag") is False
+
+    def test_bash_block_with_skip_flag_is_excluded(self, tmp_path: Path) -> None:
+        """A ```bash +RHIZA_SKIP block should not be syntax-checked."""
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "```bash +RHIZA_SKIP\nnot-valid-bash @@@@\n```\n```bash\necho hello\n```\n",
+            encoding="utf-8",
+        )
+        all_blocks = BASH_BLOCK.findall(readme.read_text(encoding="utf-8"))
+        assert len(all_blocks) == 2
+        checked = [code for flags, code in all_blocks if not _should_skip(flags)]
+        assert len(checked) == 1
+        assert "not-valid-bash" not in checked[0]

--- a/.rhiza/tests/test_readme_validation.py
+++ b/.rhiza/tests/test_readme_validation.py
@@ -1,10 +1,19 @@
-"""Tests for README code examples.
+"""Tests for executable Python examples in the README.
 
 This file and its associated tests flow down via a SYNC action from the jebel-quant/rhiza repository
 (https://github.com/jebel-quant/rhiza).
 
 This module extracts Python code and expected result blocks from README.md,
 executes the code, and verifies the output matches the documented result.
+
+The language-neutral half — that the README exists, and that its ``bash`` fences
+parse — moved to ``core``'s ``test_readme.py`` in #1472, so a Rust or Go project gets it
+too. What stays here only means something where the project itself is Python: running a
+``python`` fence and diffing it against the following ``result`` block.
+
+``SKIP_FLAG`` and ``_should_skip`` are duplicated with that module rather than shared.
+Bundles are copied independently, so a shared helper would need a third home both bundles
+ship — a worse trade for four lines.
 """
 
 import re
@@ -17,12 +26,6 @@ import pytest
 CODE_BLOCK = re.compile(r"```python([^\n]*)\n(.*?)```", re.DOTALL)
 
 RESULT = re.compile(r"```result\n(.*?)```", re.DOTALL)
-
-# Regex for Bash code blocks — captures optional flags and the code body.
-BASH_BLOCK = re.compile(r"```bash([^\n]*)\n(.*?)```", re.DOTALL)
-
-# Bash executable used for syntax checking; subprocess.run below is trusted (noqa: S603).
-BASH = "bash"
 
 # Flag that marks a code block as intentionally excluded from readme tests.
 # Usage: add the flag after the language identifier on the opening fence line,
@@ -80,19 +83,6 @@ def test_readme_runs(logger, root):
 class TestReadmeTestEdgeCases:
     """Edge cases for README code block testing."""
 
-    def test_readme_file_exists_at_root(self, root):
-        """README.md should exist at repository root."""
-        readme = root / "README.md"
-        assert readme.exists()
-        assert readme.is_file()
-
-    def test_readme_is_readable(self, root):
-        """README.md should be readable with UTF-8 encoding."""
-        readme = root / "README.md"
-        content = readme.read_text(encoding="utf-8")
-        assert len(content) > 0
-        assert isinstance(content, str)
-
     def test_readme_code_is_syntactically_valid(self, root):
         """Python code blocks in README should be syntactically valid (skipped blocks are excluded)."""
         readme = root / "README.md"
@@ -108,51 +98,8 @@ class TestReadmeTestEdgeCases:
                 pytest.fail(f"Code block {i} has syntax error: {e}")
 
 
-class TestReadmeBashFragments:
-    """Tests for bash code fragments in README."""
-
-    def test_bash_blocks_basic_syntax(self, root, logger):
-        """Bash code blocks should have basic valid syntax (can be parsed by bash -n)."""
-        readme = root / "README.md"
-        content = readme.read_text(encoding="utf-8")
-        bash_blocks = BASH_BLOCK.findall(content)
-
-        logger.info("Found %d bash code block(s) in README", len(bash_blocks))
-
-        for i, (flags, code) in enumerate(bash_blocks):
-            if _should_skip(flags):
-                logger.info("Skipping bash block %d (%s flag)", i, SKIP_FLAG)
-                continue
-
-            # Skip directory tree representations and other non-executable blocks
-            if any(marker in code for marker in ["├──", "└──", "│"]):
-                logger.info("Skipping bash block %d (directory tree representation)", i)
-                continue
-
-            # Skip blocks that are primarily comments or documentation
-            lines = [line.strip() for line in code.split("\n") if line.strip()]
-            non_comment_lines = [line for line in lines if not line.startswith("#")]
-            if not non_comment_lines:
-                logger.info("Skipping bash block %d (only comments)", i)
-                continue
-
-            logger.debug("Checking bash block %d:\n%s", i, code)
-
-            # Use bash -n to check syntax without executing
-            # Trust boundary: we use bash -n which only parses without executing
-            result = subprocess.run(  # nosec
-                [BASH, "-n"],
-                input=code,
-                capture_output=True,
-                text=True,
-            )
-
-            if result.returncode != 0:
-                pytest.fail(f"Bash block {i} has syntax errors:\nCode:\n{code}\nError:\n{result.stderr}")
-
-
 class TestSkipFlag:
-    """Tests for the +RHIZA_SKIP flag that allows individual README code blocks to be excluded."""
+    """Tests for the +RHIZA_SKIP flag as it applies to Python fences."""
 
     def test_should_skip_returns_true_for_skip_flag(self):
         """+RHIZA_SKIP in flags string should cause _should_skip to return True."""
@@ -181,17 +128,3 @@ class TestSkipFlag:
         executed = [code for flags, code in all_blocks if not _should_skip(flags)]
         assert len(executed) == 1
         assert "raise RuntimeError" not in executed[0]
-
-    def test_bash_block_with_skip_flag_is_excluded(self, tmp_path):
-        """A ```bash +RHIZA_SKIP block should not be syntax-checked."""
-        readme = tmp_path / "README.md"
-        readme.write_text(
-            "```bash +RHIZA_SKIP\nnot-valid-bash @@@@\n```\n```bash\necho hello\n```\n",
-            encoding="utf-8",
-        )
-        content = readme.read_text(encoding="utf-8")
-        all_blocks = BASH_BLOCK.findall(content)
-        assert len(all_blocks) == 2
-        checked = [code for flags, code in all_blocks if not _should_skip(flags)]
-        assert len(checked) == 1
-        assert "not-valid-bash" not in checked[0]

--- a/.rhiza/tests/test_release_tags.py
+++ b/.rhiza/tests/test_release_tags.py
@@ -1,0 +1,63 @@
+"""Tests for the release tags every language layer's version config derives from.
+
+This file and its associated tests flow down via a SYNC action from the
+jebel-quant/rhiza repository (https://github.com/jebel-quant/rhiza).
+
+Owned by ``core`` because the invariant is about git, not about a language. All three
+layers depend on it for the same reason: ``python-core``'s ``[tool.bumpversion]`` table
+and the root ``.bumpversion.toml`` that ``rust-core`` and ``go-core`` ship both fall back
+to reading the newest tag when they cannot read a version from a file, and git-cliff
+places changelog boundaries at tags. An unreachable tag breaks both.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess  # nosec B404
+from pathlib import Path
+
+import pytest
+
+_GIT = shutil.which("git") or "/usr/bin/git"
+
+
+def test_latest_tag_is_reachable_from_a_branch(latest_tag: str, root: Path) -> None:
+    """The newest tag must sit on a commit some branch contains (#1454).
+
+    ``git tag --list`` happily reports an orphaned tag, which is how a repo can stay
+    green while ``git describe`` disagrees with it. A release cut on a branch that is
+    then squash-merged leaves its tag on the pre-squash commit while the content lands
+    on the default branch under a new SHA; no branch contains the tagged commit any
+    more.
+
+    The consequence is not cosmetic. git-cliff cannot place a boundary at an
+    unreachable tag, so regenerating CHANGELOG.md deletes that version's section and
+    folds its commits into the next release. Bump tooling reading the version from
+    ``git describe`` skips the release for the same reason.
+    """
+    if (
+        subprocess.run(  # nosec B603
+            [_GIT, "rev-parse", "--is-shallow-repository"], capture_output=True, text=True, cwd=root
+        ).stdout.strip()
+        == "true"
+    ):
+        pytest.skip("shallow clone — the commit graph is incomplete")
+
+    commit = subprocess.run(  # nosec B603
+        [_GIT, "rev-parse", f"{latest_tag}^{{commit}}"], capture_output=True, text=True, cwd=root
+    )
+    if commit.returncode != 0:
+        pytest.skip(f"tagged commit for {latest_tag} is not present locally")
+
+    contains = subprocess.run(  # nosec B603
+        [_GIT, "branch", "-a", "--contains", commit.stdout.strip(), "--format=%(refname:short)"],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+    assert contains.stdout.strip(), (
+        f"Tag {latest_tag} points at {commit.stdout.strip()[:12]}, which no branch contains. "
+        f"It is most likely the pre-squash commit of a squash-merged release branch: "
+        f"`git describe` skips this release and regenerating CHANGELOG.md will delete its "
+        f"section. Re-tag the merged commit and delete the orphaned tag."
+    )

--- a/cliff.toml
+++ b/cliff.toml
@@ -66,7 +66,14 @@ sort_commits = "oldest"
 commit_parsers = [
   # Drop automated noise commits that don't provide user-facing signal.
   { message = ".*\\[skip ci\\].*", skip = true },
-  { message = "^chore(\\([^)]+\\))?:\\s*(bump|release)( version)?\\b", skip = true },
+  # Only the release flow's own commits. A bare `bump` alternative here also ate every
+  # `chore(deps): bump <dependency>` — the rhiza-hooks v1.2.0 bump (#1487) vanished from
+  # v1.3.2's notes that way, and had been vanishing for a while unnoticed: a Dependabot
+  # subject escapes by the accident of its doubled `(deps)(deps)` scope, and #1482's
+  # identical bump survived only because it was typed `fix(deps):`. So this names
+  # `release` and the older `bump version` form explicitly rather than `bump` at large.
+  { message = "^chore(\\([^)]+\\))?:\\s*release\\b", skip = true },
+  { message = "^chore(\\([^)]+\\))?:\\s*bump version\\b", skip = true },
   { message = "^chore:\\s*update changelog\\.md\\b", skip = true },
   { message = "^feat", group = "<!-- 0 -->New Features" },
   { message = "^fix", group = "<!-- 1 -->Bug Fixes" },

--- a/tests/test_rhiza_packaging.py
+++ b/tests/test_rhiza_packaging.py
@@ -1,0 +1,97 @@
+"""The first test a freshly synced Python project has.
+
+This file flows down via a SYNC action from the jebel-quant/rhiza repository
+(https://github.com/jebel-quant/rhiza).
+
+**Why it exists.** Two reasons, and the second is the one that is easy to lose.
+
+It checks a real invariant: that the version the project *declares* in
+``pyproject.toml`` is the version actually installed into the environment. Those drift
+apart more often than anything else on a fresh checkout — an editable install left over
+from a rename, a `uv sync` that never ran, a package directory the build backend is not
+configured to pick up. Each shows up here as a mismatch rather than as a confusing
+ImportError three files later.
+
+And it is the only test a freshly synced project has. ``make test`` searches
+``TESTS_FOLDER`` for ``test_*.py``/``*_test.py``, and finding none it prints a warning
+and **exits 0** — so a new repo passed ``make test``, and therefore ``make all``, while
+measuring nothing (#1476). That was the third instance of one pattern: Go had it until
+``go-core`` shipped ``internal/version/version_test.go`` (#1467), and ``rhiza-test`` had
+it until the ``.rhiza/tests`` suite was actually delivered to every layer (#1469). Rust
+never did, because ``cargo init --lib`` leaves an ``it_works`` test behind.
+
+Writing your own tests alongside this is the point. Deleting it and shipping nothing
+else puts the vacuum back.
+
+**Why not simply fail when no tests exist?** Because that turns ``make all`` red on the
+output of ``/rhiza:init``, before the author has written a line. The warning branch is
+deliberate; what it needed was something to find.
+
+Deliberately self-contained: it uses no fixtures, because this lives in *your* ``tests/``
+directory and must not depend on the ``conftest.py`` that ships with ``.rhiza/tests``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as installed_version
+from pathlib import Path
+
+import pytest
+
+# tests/ sits at the project root, so the parent of this file's directory is the root.
+#
+# `.absolute()`, never `.resolve()`. In a synced project the difference is nil, but in
+# rhiza's own repository this file is a *symlink* into `bundles/python-core/tests/`, and
+# `.resolve()` follows it — making the "project root" come out as `bundles/python-core`,
+# which has no pyproject.toml. The suite then skips for a plausible-looking wrong reason
+# instead of running. `.rhiza/tests/conftest.py` avoids the same trap the same way.
+_ROOT = Path(__file__).absolute().parent.parent
+
+
+def _project_table() -> dict:
+    """Return the ``[project]`` table from pyproject.toml, skipping when unusable.
+
+    Returns:
+        The parsed ``[project]`` table.
+    """
+    pyproject = _ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        pytest.skip("no pyproject.toml at the project root")
+    with pyproject.open("rb") as handle:
+        table = tomllib.load(handle).get("project")
+    if not isinstance(table, dict):
+        pytest.skip("pyproject.toml declares no [project] table")
+    return table
+
+
+def test_the_installed_version_matches_pyproject() -> None:
+    """The distribution installed in the environment must match the declared version.
+
+    Skips rather than fails when the project is not installed as a distribution at all —
+    a ``uv`` *virtual* project (no ``[build-system]``, ``source = {{ virtual = "." }}`` in
+    the lockfile) has no metadata to read, and rhiza's own repository is one. That is a
+    real configuration, not a broken one, so it is not this test's business.
+    """
+    project = _project_table()
+
+    name = project.get("name")
+    if not isinstance(name, str) or not name.strip():
+        pytest.skip("[project].name is missing or not a plain string")
+
+    declared = project.get("version")
+    if not isinstance(declared, str):
+        pytest.skip("[project].version is dynamic — there is no static value to compare")
+
+    try:
+        found = installed_version(name)
+    except PackageNotFoundError:
+        pytest.skip(f"{name!r} is not installed as a distribution (a virtual project has no metadata)")
+
+    assert found == declared, (
+        f"pyproject.toml declares version {declared!r} but the installed {name!r} reports "
+        f"{found!r}. The environment is stale or the build backend is picking up a different "
+        f"tree — re-run `make install`, and check [build-system] and the packages it is told "
+        f"to include if that does not fix it."
+    )


### PR DESCRIPTION
Template sync from `jebel-quant/rhiza`: **v1.2.5 → v1.3.2** (upstream `996d5df684d8`).

- **30 files changed** by the sync: 28 merged, 1 deleted, plus `template.yml` and `template.lock`.
- **Conflicts resolved, taking upstream**: `.rhiza/tests/test_pyproject.py` (2 blocks). A rhiza-managed file is the template's to own, so local divergence there is drift to undo.
- **Left unstaged**: `.rhiza/.cfg.toml` (deletion) — not template-owned, so it stays in the working tree for a maintainer to decide on.

Only template-owned paths are in this PR — the staged set comes mechanically from `template.lock`'s `files` list.

**No gates were run** — run `/rhiza:quality` for a scorecard.

---

Also normalizes the config key spelling: `template-repository`/`template-branch` -> `repository`/`ref`, matching the other cvxgrp repos. Both spellings are accepted by the template (`_rhiza_template.py` prefers `repository`/`ref` and falls back to the older names), and `validate.py` passes on the new form.
