### PR TITLE
Enforce Builder's abstract objective and correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # [cvxmarkowitz](http://www.cvxgrp.org/cvxmarkowitz)
 
-[![PyPI version](https://badge.fury.io/py/cvxmarkowitz.svg)](https://badge.fury.io/py/cvxmarkowitz)
-[![Apache 2.0 License](https://img.shields.io/badge/License-APACHEv2-brightgreen.svg)](https://github.com/cvxgrp/cvxmarkowitz/blob/master/LICENSE)
+[![Apache 2.0 License](https://img.shields.io/badge/License-APACHEv2-brightgreen.svg)](https://github.com/cvxgrp/cvxmarkowitz/blob/main/LICENSE)
 [![Coverage](https://www.cvxgrp.org/cvxmarkowitz/coverage-badge.svg)](https://www.cvxgrp.org/cvxmarkowitz/reports/html-coverage/)
 
 ## Motivation
@@ -32,7 +31,7 @@ added.
 Every problem has to be constructed by a Builder. Here's a builder for a classic
 [minimum variance problem](src/cvxmarkowitz/portfolios/min_var.py).
 The builder inherits from the [Builder](src/cvxmarkowitz/builder.py)
-and implements the abstract method [build](src/cvxmarkowitz/builder.py#L95).
+and implements the abstract property [objective](src/cvxmarkowitz/builder.py#L92).
 The builder remains flexible. At this stage it is possible to add or remove
 constraints. Only once we trigger the build() method do we construct
 the problem and compile it.
@@ -42,10 +41,10 @@ we use the [update](src/cvxmarkowitz/problem.py#L84) method.
 
 ## Installation
 
-You can install the package via [PyPI](https://pypi.org/project/cvxmarkowitz/):
+The package is not published on PyPI. Install it from the git source:
 
 ```bash
-pip install cvxmarkowitz
+pip install git+https://github.com/cvxgrp/cvxmarkowitz
 ```
 
 ## Usage

--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 import cvxpy as cp
@@ -36,7 +36,7 @@ __all__ = ["Builder", "CvxError", "_Problem", "deserialize"]
 
 
 @dataclass(frozen=True)
-class Builder:
+class Builder(ABC):
     """Assemble variables, models, and constraints for Markowitz problems.
 
     Attributes:

--- a/tests/test_markowitz/test_builder.py
+++ b/tests/test_markowitz/test_builder.py
@@ -80,6 +80,12 @@ def test_infeasible_problem():
         problem.solve(solver=cp.CLARABEL)
 
 
+def test_builder_is_abstract():
+    """The base Builder should not be instantiable without an objective."""
+    with pytest.raises(TypeError, match="objective"):
+        Builder(assets=3)
+
+
 def test_builder_risk():
     """The builder.risk property should reference the risk model in model dict."""
     builder = DummyBuilder(assets=1)


### PR DESCRIPTION
Closes #557. Closes #558.

## #557 — `Builder` had no `ABC` base

`Builder` marked `objective` as `@abstractmethod` but declared no `ABC` base. Without `ABCMeta` in the metaclass chain the decorator is inert, so `Builder(assets=3)` constructed successfully and `objective` evaluated to `None`. `build()` then passed that `None` into `cp.Problem`, so the failure surfaced inside cvxpy's canonicalization rather than as a clear `TypeError` at construction. `Model` already derives from `ABC`, so this was an inconsistency, not house style.

Adding the base makes it explicit:

```
TypeError: Can't instantiate abstract class Builder without an implementation for abstract method 'objective'
```

`MinVar`, `MaxSharpe`, `SoftRisk` and the test suite's `DummyBuilder` all implement `objective` and are unaffected. A `test_builder_is_abstract` case now pins the behaviour.

## #558 — four README inaccuracies

1. **PyPI badge and install command** — the package is not on PyPI, and `pyproject.toml` deliberately keeps the `Private :: Do Not Upload` marker that `rhiza_release.yml` greps for. Dropped the version badge and pointed installation at the git source. This resolves the disagreement in favour of *not* publishing; flipping it the other way (removing the marker) is the alternative if the package should actually ship.
2. **Wrong abstract member** — the README named the concrete `build`; the abstract member is the `objective` property. Also corrected the line anchor `#L95` → `#L92`.
3. **Stale branch in LICENSE link** — `blob/master` → `blob/main`.

## Verification

- `make test` — 63 passed, 100% coverage held
- `make rhiza-test` — 40 passed, README `python`/`result` round-trip intact
- `make fmt` — all hooks pass (markdownlint, interrogate, ruff, bandit)

One caveat on #558's "install channel that actually works": `pip install git+https://github.com/cvxgrp/cvxmarkowitz` requires repo read access, which is the same audience the README already assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)