### PR TITLE
Document the intentional test-layout deviation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,16 @@ pytest = "pytest"
 [tool.deptry.per_rule_ignores]
 DEP002 = ["clarabel", "cvx-linalg"]
 
+# Tests here are grouped by the behaviour they exercise rather than mirrored
+# one-to-one onto source modules: tests/test_markowitz/ covers src/cvxmarkowitz/
+# under a tree whose intermediate directories carry a test_ prefix, so the parity
+# checker reads every module as both untested and orphaned. Per-module coverage is
+# guaranteed instead by the coverage gate: Makefile sets COVERAGE_FAIL_UNDER = 100,
+# raising the template's default of 90, and `make test` reports 442/442 statements.
+[tool.check_test_layout]
+enforce = false
+reason = "Tests are grouped by behaviour under tests/test_markowitz/; per-module coverage is guaranteed by the full pytest coverage gate."
+
 [tool.mypy]
 # cvxpy ships an incomplete py.typed surface: its functional atoms
 # (cp.norm2, cp.sum, cp.abs, cp.hstack, ...) are exported dynamically and are


### PR DESCRIPTION
Closes #562.

Took the recommended option — record the deviation via the checker's documented opt-out — rather than renaming the test tree.

## What was failing

`check_test_layout.py` exited 1 with 32 complaints, 18 "missing test file" and 14 "orphan test file", each module appearing on both lists:

```
✗ missing test file tests/cvxmarkowitz/test_builder.py for source module src/cvxmarkowitz/builder.py
✗ orphan test file tests/test_markowitz/test_builder.py (no source module src/test_markowitz/builder.py)
```

The cause is a tree-name mismatch: tests live under `tests/test_markowitz/` while source is `src/cvxmarkowitz/`, and the intermediate directories carry a `test_` prefix the source ones don't (`test_models/` vs `models/`). So it describes a naming convention, not absent tests.

## Why opt out rather than mirror

The opt-out requires an alternative guarantee, and this repo has a real one: `Makefile:12` sets `COVERAGE_FAIL_UNDER = 100`, raising the template's default of 90. No source module can go untested whatever the test tree is called — `make test` reports 442/442 statements with zero misses.

Renaming would have touched twenty-odd paths for the same mark. The `reason` field is required by the checker precisely so this choice stays visible rather than silent.

```toml
[tool.check_test_layout]
enforce = false
reason = "Tests are grouped by behaviour under tests/test_markowitz/; per-module coverage is guaranteed by the full pytest coverage gate."
```

**Worth noting for a follow-up:** three files wouldn't mirror even after a rename, and the opt-out covers them too rather than fixing them — `test_bounds.py` sits at the top level though `bounds.py` is in `models/`; `test_portfolios/test_problem.py` tests top-level `problem.py`; and `test_utils/test_aux.py` doesn't name its subject (`utils/fill.py`). Cheap to tidy independently if you want the tree self-describing.

## Verification

- `check_test_layout.py` exits 0: `Test layout OK: parity not enforced by request — …`
- `make test` — 63 passed, 442/442 statements, coverage gate satisfied at 100%
- `make rhiza-test` — 40 passed, including the `[project]` structure tests over the edited `pyproject.toml`
- `make fmt` — green, including `check toml` and `Validate pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)