### PR TITLE
Public API, error taxonomy, dead imports, bandit noise and README round-trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ so subsequent solves reuse the cached compilation.
 import numpy as np
 from cvx.linalg import cholesky
 
+from cvxmarkowitz import MinVar
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.portfolios.min_var import MinVar
 
 # Build a long-only, budget-constrained minimum-variance problem for 4 assets.
 problem = MinVar(assets=4).build()
@@ -84,6 +84,60 @@ print("weights:", np.round(problem.weights, 3))
 objective: 0.9354
 weights: [0.75 0.25 0.   0.  ]
 ```
+
+### Reusing a compiled problem across sessions
+
+A built problem can be written to disk and loaded back, so the cvxpy
+compilation survives a restart. Serialize **before** solving: a solved problem
+holds a live solver handle that cannot be pickled.
+
+```python
+import tempfile
+from pathlib import Path
+
+from cvxmarkowitz import deserialize
+
+data = {
+    D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
+    D.LOWER_BOUND_ASSETS: np.zeros(2),
+    D.UPPER_BOUND_ASSETS: np.ones(2),
+    D.VOLA_UNCERTAINTY: np.zeros(2),
+}
+
+with tempfile.TemporaryDirectory() as tmp:
+    path = Path(tmp) / "problem.pkl"
+
+    # Build and store the compiled problem without solving it.
+    MinVar(assets=4).build().serialize(path)
+
+    # Later, or in another process: load it and solve.
+    recovered = deserialize(path, trusted=True)
+    recovered.update(**data)
+    print("recovered objective:", round(recovered.solve(), 4))
+```
+
+```result
+recovered objective: 0.9354
+```
+
+> **`deserialize` executes arbitrary code.** It is `pickle.load` underneath, so
+> loading a file is equivalent to running whatever that file's author chose to
+> run. The `trusted=True` flag is a deliberate gate, not a formality: without it
+> the call raises `CvxTrustError` rather than unpickling. Only ever pass it for a
+> file you produced yourself with `serialize`, and never for one received over a
+> network or from an untrusted source.
+
+## Errors
+
+Everything the package raises derives from `CvxError`, so a single
+`except CvxError` still catches all of it. Three subclasses separate the failure
+modes that want different handling:
+
+| Error | Raised when | Retry helps? |
+|---|---|---|
+| `CvxDataError` | required data is missing, or shapes disagree | yes, with corrected input |
+| `CvxSolverError` | the solver returned a non-optimal status | no — try another solver or relax the problem |
+| `CvxTrustError` | `deserialize` was called without `trusted=True` | no — it is a security guard |
 
 ## Development
 

--- a/src/cvxmarkowitz/__init__.py
+++ b/src/cvxmarkowitz/__init__.py
@@ -16,7 +16,10 @@
 from __future__ import annotations
 
 from .builder import Builder as Builder
+from .cvxerror import CvxDataError as CvxDataError
 from .cvxerror import CvxError as CvxError
+from .cvxerror import CvxSolverError as CvxSolverError
+from .cvxerror import CvxTrustError as CvxTrustError
 from .portfolios.max_sharpe import MaxSharpe as MaxSharpe
 from .portfolios.min_var import MinVar as MinVar
 from .portfolios.soft_risk import SoftRisk as SoftRisk
@@ -25,7 +28,10 @@ from .problem import deserialize as deserialize
 
 __all__ = [
     "Builder",
+    "CvxDataError",
     "CvxError",
+    "CvxSolverError",
+    "CvxTrustError",
     "MaxSharpe",
     "MinVar",
     "Problem",

--- a/src/cvxmarkowitz/__init__.py
+++ b/src/cvxmarkowitz/__init__.py
@@ -12,3 +12,23 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 """Markowitz portfolio optimization package."""
+
+from __future__ import annotations
+
+from .builder import Builder as Builder
+from .cvxerror import CvxError as CvxError
+from .portfolios.max_sharpe import MaxSharpe as MaxSharpe
+from .portfolios.min_var import MinVar as MinVar
+from .portfolios.soft_risk import SoftRisk as SoftRisk
+from .problem import Problem as Problem
+from .problem import deserialize as deserialize
+
+__all__ = [
+    "Builder",
+    "CvxError",
+    "MaxSharpe",
+    "MinVar",
+    "Problem",
+    "SoftRisk",
+    "deserialize",
+]

--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -25,14 +25,14 @@ from cvxmarkowitz.model import Model
 from cvxmarkowitz.models.bounds import Bounds
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
-from cvxmarkowitz.problem import _Problem, deserialize
+from cvxmarkowitz.problem import Problem, deserialize
 from cvxmarkowitz.risk.factor.factor import FactorModel
 from cvxmarkowitz.risk.sample.sample import SampleCovariance
 from cvxmarkowitz.types import Parameter, Variables
 
-# Re-exported for backwards compatibility: ``deserialize``/``_Problem`` moved to
+# Re-exported for backwards compatibility: ``deserialize``/``Problem`` moved to
 # cvxmarkowitz.problem, ``CvxError`` lives in cvxmarkowitz.cvxerror.
-__all__ = ["Builder", "CvxError", "_Problem", "deserialize"]
+__all__ = ["Builder", "CvxError", "Problem", "deserialize"]
 
 
 @dataclass(frozen=True)
@@ -92,7 +92,7 @@ class Builder(ABC):
     def objective(self) -> cp.Minimize | cp.Maximize:
         """Return the objective function."""
 
-    def build(self) -> _Problem:
+    def build(self) -> Problem:
         """Build the cvxpy problem."""
         for name_model, model in self.model.items():
             for name_constraint, constraint in model.constraints(self.variables).items():
@@ -101,7 +101,7 @@ class Builder(ABC):
         problem = cp.Problem(self.objective, list(self.constraints.values()))
         assert problem.is_dpp(), "Problem is not DPP"  # noqa: S101
 
-        return _Problem(problem=problem, model=self.model)
+        return Problem(problem=problem, model=self.model)
 
     @property
     def weights(self) -> cp.Variable:

--- a/src/cvxmarkowitz/cvxerror.py
+++ b/src/cvxmarkowitz/cvxerror.py
@@ -15,4 +15,36 @@
 
 
 class CvxError(Exception):
-    """Generic error raised for invalid model/problem configurations."""
+    """Base error for the package.
+
+    Every error raised by cvxmarkowitz derives from this, so
+    ``except CvxError`` continues to catch all of them. Prefer catching one
+    of the subclasses below when the handling differs by failure mode.
+    """
+
+
+class CvxDataError(CvxError):
+    """Input data is missing, or its shape disagrees with the model.
+
+    Raised when required keyword data is absent, or when arrays that must
+    agree in length or shape do not. Recoverable by supplying corrected
+    input and retrying.
+    """
+
+
+class CvxSolverError(CvxError):
+    """The solver returned a non-optimal status.
+
+    Raised when a problem is infeasible, unbounded, or otherwise did not
+    solve to optimality. Retrying with the same input will not help;
+    another solver or a relaxed formulation might.
+    """
+
+
+class CvxTrustError(CvxError):
+    """A trust boundary was crossed without explicit consent.
+
+    Raised when :func:`~cvxmarkowitz.problem.deserialize` is called without
+    ``trusted=True``. This is a security guard, not a transient failure —
+    catching it to retry with ``trusted=True`` defeats its purpose.
+    """

--- a/src/cvxmarkowitz/models/bounds.py
+++ b/src/cvxmarkowitz/models/bounds.py
@@ -21,7 +21,7 @@ import cvxpy as cp
 import numpy as np
 
 from cvxmarkowitz.model import Model
-from cvxmarkowitz.types import Constraints, Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Constraints, Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_vector
 
 

--- a/src/cvxmarkowitz/models/expected_returns.py
+++ b/src/cvxmarkowitz/models/expected_returns.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 import cvxpy as cp
 import numpy as np
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.cvxerror import CvxDataError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.types import Matrix, Variables
@@ -71,6 +71,6 @@ class ExpectedReturns(Model):
         # Robust return estimate
         uncertainty = kwargs["mu_uncertainty"]
         if not uncertainty.shape[0] == exp_returns.shape[0]:
-            raise CvxError("Mismatch in length for mu and mu_uncertainty")  # noqa: TRY003
+            raise CvxDataError("Mismatch in length for mu and mu_uncertainty")  # noqa: TRY003
 
         self.parameter["mu_uncertainty"].value = fill_vector(num=self.assets, x=uncertainty)

--- a/src/cvxmarkowitz/models/expected_returns.py
+++ b/src/cvxmarkowitz/models/expected_returns.py
@@ -23,7 +23,7 @@ import numpy as np
 from cvxmarkowitz.cvxerror import CvxError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_vector
 
 

--- a/src/cvxmarkowitz/models/holding_costs.py
+++ b/src/cvxmarkowitz/models/holding_costs.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_vector
 
 

--- a/src/cvxmarkowitz/models/trading_costs.py
+++ b/src/cvxmarkowitz/models/trading_costs.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_vector
 
 

--- a/src/cvxmarkowitz/portfolios/max_sharpe.py
+++ b/src/cvxmarkowitz/portfolios/max_sharpe.py
@@ -20,12 +20,10 @@ from dataclasses import dataclass
 import cvxpy as cp
 
 from cvxmarkowitz.builder import Builder
-from cvxmarkowitz.model import Model  # noqa: F401
 from cvxmarkowitz.models.expected_returns import ExpectedReturns
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import ModelName as M
 from cvxmarkowitz.names import ParameterName as P
-from cvxmarkowitz.types import Parameter, Variables  # noqa: F401
 
 
 @dataclass(frozen=True)

--- a/src/cvxmarkowitz/portfolios/min_var.py
+++ b/src/cvxmarkowitz/portfolios/min_var.py
@@ -20,9 +20,7 @@ from dataclasses import dataclass
 import cvxpy as cp
 
 from cvxmarkowitz.builder import Builder
-from cvxmarkowitz.model import Model  # noqa: F401
 from cvxmarkowitz.names import ConstraintName as C
-from cvxmarkowitz.types import Parameter, Variables  # noqa: F401
 
 
 @dataclass(frozen=True)

--- a/src/cvxmarkowitz/portfolios/soft_risk.py
+++ b/src/cvxmarkowitz/portfolios/soft_risk.py
@@ -20,12 +20,10 @@ from dataclasses import dataclass, field
 import cvxpy as cp
 
 from cvxmarkowitz.builder import Builder
-from cvxmarkowitz.model import Model  # noqa: F401
 from cvxmarkowitz.models.expected_returns import ExpectedReturns
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import ModelName as M
 from cvxmarkowitz.names import ParameterName as P
-from cvxmarkowitz.types import Parameter, Variables  # noqa: F401
 
 
 @dataclass(frozen=True)

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -41,7 +41,7 @@ def deserialize(
 
         This uses :func:`pickle.load`, which executes arbitrary code while
         unpickling. Only ever call this on files you produced yourself with
-        :meth:`_Problem.serialize`. Never deserialize a file received from an
+        :meth:`Problem.serialize`. Never deserialize a file received from an
         untrusted or unauthenticated source — doing so is equivalent to
         running that source's code on your machine.
 
@@ -51,12 +51,12 @@ def deserialize(
     than silently unpickling.
 
     Args:
-        problem_file: Path to the pickle file created by `_Problem.serialize`.
+        problem_file: Path to the pickle file created by `Problem.serialize`.
         trusted: Must be set to ``True`` to confirm the file originates from a
             trusted source. Defaults to ``False``, which refuses to load.
 
     Returns:
-        The deserialized `_Problem` instance.
+        The deserialized `Problem` instance.
 
     Raises:
         CvxError: If ``trusted`` is not explicitly set to ``True``.
@@ -65,7 +65,7 @@ def deserialize(
         raise CvxError(  # noqa: TRY003
             "Refusing to deserialize: pickle.load executes arbitrary code. "
             "Pass trusted=True only for a file you produced yourself with "
-            "_Problem.serialize()."
+            "Problem.serialize()."
         )
     # nosec B301 / noqa: S301: pickle is the intended format for round-tripping a
     # built problem. The trust boundary is guarded by the trusted flag above; the
@@ -75,13 +75,13 @@ def deserialize(
 
 
 @dataclass(frozen=True)
-class _Problem:
+class Problem:
     """Frozen container holding a built cvxpy problem and its named models."""
 
     problem: cp.Problem
     model: dict[str, Model] = field(default_factory=dict)
 
-    def update(self, **kwargs: Matrix) -> _Problem:
+    def update(self, **kwargs: Matrix) -> Problem:
         """Update the problem."""
         for name, model in self.model.items():
             for key in model.data:

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -67,9 +67,9 @@ def deserialize(
             "Pass trusted=True only for a file you produced yourself with "
             "Problem.serialize()."
         )
-    # nosec B301 / noqa: S301: pickle is the intended format for round-tripping a
-    # built problem. The trust boundary is guarded by the trusted flag above; the
-    # input is assumed to be a self-produced serialize() file.
+    # pickle is the intended format for round-tripping a built problem. The trust
+    # boundary is guarded by the trusted flag above; the input is assumed to be a
+    # self-produced serialize() file. Suppressions are on the call itself below.
     with open(problem_file, "rb") as infile:
         return pickle.load(infile)  # nosec B301  # noqa: S301
 

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -24,7 +24,7 @@ from typing import Any
 import cvxpy as cp
 import numpy as np
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.cvxerror import CvxDataError, CvxSolverError, CvxTrustError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.types import File, Matrix, Parameter, Variables
@@ -62,7 +62,7 @@ def deserialize(
         CvxError: If ``trusted`` is not explicitly set to ``True``.
     """
     if not trusted:
-        raise CvxError(  # noqa: TRY003
+        raise CvxTrustError(  # noqa: TRY003
             "Refusing to deserialize: pickle.load executes arbitrary code. "
             "Pass trusted=True only for a file you produced yourself with "
             "Problem.serialize()."
@@ -86,7 +86,7 @@ class Problem:
         for name, model in self.model.items():
             for key in model.data:
                 if key not in kwargs:
-                    raise CvxError(f"Missing data for {key} in model {name}")  # noqa: TRY003
+                    raise CvxDataError(f"Missing data for {key} in model {name}")  # noqa: TRY003
 
             # It's tempting to operate without the models at this stage.
             # However, we would give up a lot of convenience. For example,
@@ -101,7 +101,7 @@ class Problem:
         value = self.problem.solve(solver=solver, **kwargs)
 
         if self.problem.status is not cp.OPTIMAL:
-            raise CvxError(f"Problem status is {self.problem.status}")  # noqa: TRY003
+            raise CvxSolverError(f"Problem status is {self.problem.status}")  # noqa: TRY003
 
         return float(value)
 

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -180,6 +180,15 @@ class Problem:
         return np.array(self.variables[D.FACTOR_WEIGHTS].value)
 
     def serialize(self, problem_file: File) -> None:
-        """Pickle this problem to disk for later reuse with `deserialize`."""
+        """Pickle this problem to disk for later reuse with `deserialize`.
+
+        Call this before :meth:`solve`. Solving attaches a live solver handle to
+        the underlying cvxpy problem, and that handle is not picklable — a
+        solved problem raises ``TypeError: cannot pickle 'builtins.DefaultSolver'
+        object`` here.
+
+        Args:
+            problem_file: Destination path for the pickle file.
+        """
         with open(problem_file, "wb") as outfile:
             pickle.dump(self, outfile)

--- a/src/cvxmarkowitz/risk/cvar/cvar.py
+++ b/src/cvxmarkowitz/risk/cvar/cvar.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_matrix
 
 

--- a/src/cvxmarkowitz/risk/factor/factor.py
+++ b/src/cvxmarkowitz/risk/factor/factor.py
@@ -23,7 +23,7 @@ import numpy as np
 from cvxmarkowitz.cvxerror import CvxError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Constraints, Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Constraints, Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_matrix, fill_vector
 
 

--- a/src/cvxmarkowitz/risk/factor/factor.py
+++ b/src/cvxmarkowitz/risk/factor/factor.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 import cvxpy as cp
 import numpy as np
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.cvxerror import CvxDataError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.types import Constraints, Matrix, Variables
@@ -127,7 +127,7 @@ class FactorModel(Model):
         """Check that all required inputs are present and shape-consistent."""
         for key in self.data:
             if key not in kwargs:
-                raise CvxError(f"Missing keyword {key}")  # noqa: TRY003
+                raise CvxDataError(f"Missing keyword {key}")  # noqa: TRY003
 
         self._check_shapes(**kwargs)
 
@@ -136,16 +136,16 @@ class FactorModel(Model):
         k, assets = kwargs[D.EXPOSURE].shape
 
         if kwargs[D.IDIOSYNCRATIC_VOLA].shape[0] != kwargs[D.IDIOSYNCRATIC_VOLA_UNCERTAINTY].shape[0]:
-            raise CvxError("Mismatch in length for idiosyncratic_vola and idiosyncratic_vola_uncertainty")  # noqa: TRY003
+            raise CvxDataError("Mismatch in length for idiosyncratic_vola and idiosyncratic_vola_uncertainty")  # noqa: TRY003
 
         if kwargs[D.IDIOSYNCRATIC_VOLA].shape[0] != assets:
-            raise CvxError("Mismatch in length for idiosyncratic_vola and exposure")  # noqa: TRY003
+            raise CvxDataError("Mismatch in length for idiosyncratic_vola and exposure")  # noqa: TRY003
 
         if kwargs[D.SYSTEMATIC_VOLA_UNCERTAINTY].shape[0] != k:
-            raise CvxError("Mismatch in length of systematic_vola_uncertainty and exposure")  # noqa: TRY003
+            raise CvxDataError("Mismatch in length of systematic_vola_uncertainty and exposure")  # noqa: TRY003
 
         if kwargs[D.CHOLESKY].shape[0] != k:
-            raise CvxError("Mismatch in size of chol and exposure")  # noqa: TRY003
+            raise CvxDataError("Mismatch in size of chol and exposure")  # noqa: TRY003
 
     def constraints(self, variables: Variables) -> Constraints:
         """Return factor-model linking and robust-risk constraints."""

--- a/src/cvxmarkowitz/risk/sample/sample.py
+++ b/src/cvxmarkowitz/risk/sample/sample.py
@@ -23,7 +23,7 @@ import numpy as np
 from cvxmarkowitz.cvxerror import CvxError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import Constraints, Expressions, Matrix, Parameter, Variables  # noqa: F401
+from cvxmarkowitz.types import Constraints, Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_matrix, fill_vector
 
 

--- a/src/cvxmarkowitz/risk/sample/sample.py
+++ b/src/cvxmarkowitz/risk/sample/sample.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 import cvxpy as cp
 import numpy as np
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.cvxerror import CvxDataError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.types import Constraints, Matrix, Variables
@@ -66,7 +66,7 @@ class SampleCovariance(Model):
             D.VOLA_UNCERTAINTY: Nonnegative vector of per-asset uncertainty.
         """
         if not kwargs[D.CHOLESKY].shape[0] == kwargs[D.VOLA_UNCERTAINTY].shape[0]:
-            raise CvxError("Mismatch in length for chol and vola_uncertainty")  # noqa: TRY003
+            raise CvxDataError("Mismatch in length for chol and vola_uncertainty")  # noqa: TRY003
 
         self.data[D.CHOLESKY].value = fill_matrix(rows=self.assets, cols=self.assets, x=kwargs[D.CHOLESKY])
         self.data[D.VOLA_UNCERTAINTY].value = fill_vector(num=self.assets, x=kwargs[D.VOLA_UNCERTAINTY])

--- a/src/cvxmarkowitz/types.py
+++ b/src/cvxmarkowitz/types.py
@@ -23,7 +23,6 @@ import numpy.typing as npt
 File = str | bytes | PathLike[str]
 Parameter = dict[str, cp.Parameter]
 Variables = dict[str, cp.Variable]
-Expressions = dict[str, cp.Expression]
 Constraints = dict[str, cp.Constraint]
 
 Matrix: TypeAlias = npt.NDArray[np.float64]

--- a/tests/test_markowitz/test_builder.py
+++ b/tests/test_markowitz/test_builder.py
@@ -8,7 +8,7 @@ import cvxpy as cp
 import numpy as np
 import pytest
 
-from cvxmarkowitz.builder import Builder, CvxError
+from cvxmarkowitz import Builder, CvxDataError, CvxSolverError
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
@@ -53,15 +53,15 @@ def test_dummy():
 
 
 def test_missing_data():
-    """Updating with a wrong keyword should raise CvxError."""
+    """Updating with a wrong keyword should raise CvxDataError."""
     builder = DummyBuilder(assets=1)
     problem = builder.build()
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxDataError):
         problem.update(cov=np.eye(1))
 
 
 def test_infeasible_problem():
-    """Infeasible bounds should lead to a solver failure wrapped as CvxError."""
+    """Infeasible bounds should lead to a solver failure wrapped as CvxSolverError."""
     builder = DummyBuilder(assets=1)
 
     problem = builder.build()
@@ -76,7 +76,7 @@ def test_infeasible_problem():
         }
     )
 
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxSolverError):
         problem.solve(solver=cp.CLARABEL)
 
 

--- a/tests/test_markowitz/test_models/test_expected_returns.py
+++ b/tests/test_markowitz/test_models/test_expected_returns.py
@@ -9,7 +9,7 @@ import cvxpy as cp
 import numpy as np
 import pytest
 
-from cvxmarkowitz.builder import CvxError
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.models.expected_returns import ExpectedReturns
 from cvxmarkowitz.names import DataNames as D
 
@@ -57,8 +57,8 @@ def test_expected_returns_robust():
 
 
 def test_mismatch():
-    """Mismatched mu and mu_uncertainty lengths should raise CvxError."""
+    """Mismatched mu and mu_uncertainty lengths should raise CvxDataError."""
     assets = 3
     model = ExpectedReturns(assets=assets)
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxDataError):
         model.update(mu=np.array([0.1, 0.2]), mu_uncertainty=np.array([0.03]))

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -49,6 +49,27 @@ def test_deserialize_requires_trusted(tmp_path):
         deserialize(path)
 
 
+def test_serialize_after_solve_is_unsupported(tmp_path):
+    """A solved problem cannot be pickled: the solver handle is not picklable.
+
+    Args:
+        tmp_path: Pytest temporary directory for storing the pickle file.
+    """
+    problem = MinVar(assets=2).build()
+    problem.update(
+        **{
+            D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
+            D.LOWER_BOUND_ASSETS: np.zeros(2),
+            D.UPPER_BOUND_ASSETS: np.ones(2),
+            D.VOLA_UNCERTAINTY: np.zeros(2),
+        }
+    )
+    problem.solve()
+
+    with pytest.raises(TypeError, match="pickle"):
+        problem.serialize(tmp_path / "solved.pkl")
+
+
 def test_serialize(tmp_path):
     """Serialize a problem, deserialize it, and compare resulting weights.
 

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky, rand_cov
 
-from cvxmarkowitz import CvxError, MinVar, deserialize
+from cvxmarkowitz import CvxError, CvxTrustError, MinVar, deserialize
 from cvxmarkowitz.names import DataNames as D
 
 
@@ -37,12 +37,16 @@ def test_deserialize_requires_trusted(tmp_path):
     path = tmp_path / "problem.pkl"
     problem.serialize(path)
 
-    with pytest.raises(CvxError, match="trusted=True"):
+    with pytest.raises(CvxTrustError, match="trusted=True"):
         deserialize(path)
 
     # The default is False, so a positional/implicit call is also refused.
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxTrustError):
         deserialize(path, trusted=False)
+
+    # The refusal is still catchable via the package's base error.
+    with pytest.raises(CvxError):
+        deserialize(path)
 
 
 def test_serialize(tmp_path):

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -7,9 +7,8 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky, rand_cov
 
-from cvxmarkowitz.builder import CvxError, deserialize
+from cvxmarkowitz import CvxError, MinVar, deserialize
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.portfolios.min_var import MinVar
 
 
 def test_problem_data():

--- a/tests/test_markowitz/test_public_api.py
+++ b/tests/test_markowitz/test_public_api.py
@@ -1,0 +1,36 @@
+"""Tests for the package's top-level public API surface."""
+
+from __future__ import annotations
+
+import cvxmarkowitz
+
+
+def test_all_is_importable():
+    """Every name in __all__ resolves as a top-level package attribute."""
+    for name in cvxmarkowitz.__all__:
+        assert hasattr(cvxmarkowitz, name), f"{name} in __all__ but not exported"
+
+
+def test_all_names_are_public():
+    """No underscore-prefixed name is advertised as public API."""
+    assert not [name for name in cvxmarkowitz.__all__ if name.startswith("_")]
+
+
+def test_documented_entry_points_are_exported():
+    """The builders, the built problem and the error type are reachable directly."""
+    expected = {
+        "Builder",
+        "CvxError",
+        "MaxSharpe",
+        "MinVar",
+        "Problem",
+        "SoftRisk",
+        "deserialize",
+    }
+    assert expected <= set(cvxmarkowitz.__all__)
+
+
+def test_build_returns_the_exported_problem_type():
+    """Builder.build() returns the same Problem class the package exports."""
+    problem = cvxmarkowitz.MinVar(assets=3).build()
+    assert isinstance(problem, cvxmarkowitz.Problem)

--- a/tests/test_markowitz/test_public_api.py
+++ b/tests/test_markowitz/test_public_api.py
@@ -20,7 +20,10 @@ def test_documented_entry_points_are_exported():
     """The builders, the built problem and the error type are reachable directly."""
     expected = {
         "Builder",
+        "CvxDataError",
         "CvxError",
+        "CvxSolverError",
+        "CvxTrustError",
         "MaxSharpe",
         "MinVar",
         "Problem",
@@ -28,6 +31,16 @@ def test_documented_entry_points_are_exported():
         "deserialize",
     }
     assert expected <= set(cvxmarkowitz.__all__)
+
+
+def test_error_subclasses_derive_from_the_base():
+    """Catching CvxError still catches every specific error the package raises."""
+    for subclass in (
+        cvxmarkowitz.CvxDataError,
+        cvxmarkowitz.CvxSolverError,
+        cvxmarkowitz.CvxTrustError,
+    ):
+        assert issubclass(subclass, cvxmarkowitz.CvxError)
 
 
 def test_build_returns_the_exported_problem_type():

--- a/tests/test_markowitz/test_risk/test_factor/test_factor.py
+++ b/tests/test_markowitz/test_risk/test_factor/test_factor.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 from cvx.linalg import cholesky, pca, rand_cov
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
 from cvxmarkowitz.portfolios.min_var import MinVar
@@ -159,8 +159,8 @@ def test_factor_mini():
 
 
 def test_missing_key(factor_model):
-    """Updating without a required key should raise CvxError."""
-    with pytest.raises(CvxError):
+    """Updating without a required key should raise CvxDataError."""
+    with pytest.raises(CvxDataError):
         factor_model.update(
             **{
                 D.CHOLESKY: np.eye(2),
@@ -172,8 +172,8 @@ def test_missing_key(factor_model):
 
 
 def test_mismatch_idiosyncratic_vola(factor_model):
-    """Idiosyncratic_vola length mismatch vs. assets should raise CvxError."""
-    with pytest.raises(CvxError):
+    """Idiosyncratic_vola length mismatch vs. assets should raise CvxDataError."""
+    with pytest.raises(CvxDataError):
         factor_model.update(
             **{
                 D.CHOLESKY: np.eye(2),
@@ -186,8 +186,8 @@ def test_mismatch_idiosyncratic_vola(factor_model):
 
 
 def test_mismatch_exposure_idiosyncratic_vola(factor_model):
-    """Exposure shape inconsistent with vectors should raise CvxError."""
-    with pytest.raises(CvxError):
+    """Exposure shape inconsistent with vectors should raise CvxDataError."""
+    with pytest.raises(CvxDataError):
         factor_model.update(
             **{
                 D.CHOLESKY: np.eye(2),
@@ -201,7 +201,7 @@ def test_mismatch_exposure_idiosyncratic_vola(factor_model):
 
 def test_mismatch_systematic_vola(factor_model):
     """Systematic_vola_uncertainty length mismatch vs. factors should error."""
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxDataError):
         factor_model.update(
             **{
                 D.CHOLESKY: np.eye(2),
@@ -214,8 +214,8 @@ def test_mismatch_systematic_vola(factor_model):
 
 
 def test_mismatch_matrix(factor_model):
-    """Cholesky shape inconsistent with exposure matrix should raise CvxError."""
-    with pytest.raises(CvxError):
+    """Cholesky shape inconsistent with exposure matrix should raise CvxDataError."""
+    with pytest.raises(CvxDataError):
         factor_model.update(
             **{
                 D.CHOLESKY: np.eye(1),
@@ -233,7 +233,7 @@ def test_mismatch_matrix_nonsquare(factor_model):
     The 3x2 factor Cholesky has ``shape[1] == factors`` but ``shape[0] != factors``;
     the guard must check the row count, so this pins ``shape[0]`` specifically.
     """
-    with pytest.raises(CvxError, match="chol and exposure"):
+    with pytest.raises(CvxDataError, match="chol and exposure"):
         factor_model.update(
             **{
                 D.CHOLESKY: np.ones((3, 2)),

--- a/tests/test_markowitz/test_risk/test_sample/test_sample.py
+++ b/tests/test_markowitz/test_risk/test_sample/test_sample.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky
 
-from cvxmarkowitz.builder import CvxError
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.risk import SampleCovariance
 
@@ -99,10 +99,10 @@ def test_robust_sample_large():
 
 
 def test_mismatch():
-    """Updating with mismatched vector lengths should raise CvxError."""
+    """Updating with mismatched vector lengths should raise CvxDataError."""
     riskmodel = SampleCovariance(assets=4)
 
-    with pytest.raises(CvxError):
+    with pytest.raises(CvxDataError):
         riskmodel.update(
             **{
                 D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
@@ -122,7 +122,7 @@ def test_mismatch_cholesky_rows():
     """
     riskmodel = SampleCovariance(assets=2)
 
-    with pytest.raises(CvxError, match="chol and vola_uncertainty"):
+    with pytest.raises(CvxDataError, match="chol and vola_uncertainty"):
         riskmodel.update(
             **{
                 D.CHOLESKY: np.ones((3, 2)),


### PR DESCRIPTION
Closes #563. Closes #564. Closes #565. Closes #566. Closes #567.

Five findings from the `/rhiza:quality` run, on one branch because they overlap: #563 creates the public surface that #565 and #567 both extend. One commit per issue, in dependency order.

## #563 — Make `Problem` public

`_Problem` was what `build()` returns and the object every method in the README's workflow belongs to (`update`, `solve`, `weights`), yet its underscore said "private". It was already in `builder.py`'s `__all__`, which is the contradiction in one line. Renamed to `Problem`.

The top-level package exported nothing, so users imported from deep module paths and depended on the internal layout. `risk/__init__.py` already did this right with `as` aliasing and an explicit `__all__`; the top level now follows that pattern.

No compatibility alias — the package is at v0.0.1 and the old name was never meaningfully public.

## #564 — Dead `Expressions` alias

`types.py` defined `Expressions` and six modules imported it behind `# noqa: F401`. Nothing used it. That is the specific harm of a line-level suppression: the other names on those lines *were* in use, so the noqa did real work while covering for the one dead name alongside.

Dropping it removed the need for the suppression, and `ruff --fix` then found four more unused imports the same suppressions had hidden — `Model` in all three portfolio builders, plus `Parameter`/`Variables`. No `# noqa: F401` remains in `src/`.

## #565 — Split `CvxError`

One type served three unrelated failures, so callers could only discriminate by matching message strings. The test suite showed the cost: `test_missing_data` and `test_infeasible_problem` both asserted the same bare `CvxError`, so neither pinned what it was exercising.

Added `CvxDataError`, `CvxSolverError`, `CvxTrustError`, all deriving from `CvxError` so `except CvxError` keeps working. Tests now assert the specific subclass, with two new cases pinning that each derives from the base and that the deserialize refusal is still catchable as `CvxError`.

## #566 — bandit comment noise

The comment above `pickle.load` opened with `# nosec B301 / noqa: S301:` followed by prose, so bandit parsed each word as a test ID and emitted ten `Test in comment` warnings per run. The suppressions that matter were already well-formed on the call itself. Dropped the tokens from the prose; `make security` is now silent.

## #567 — README round-trip

Switched the usage example to top-level imports and documented the serialize/deserialize round-trip plus an error-taxonomy table.

**Writing this surfaced a real bug in the docs-vs-reality gap:** `serialize()` fails on a *solved* problem — solving attaches a live solver handle and `pickle` rejects it with `cannot pickle 'builtins.DefaultSolver' object`. The existing test only ever serialized freshly built problems, so nothing caught it. The README example now serializes before solving and says why, `serialize()`'s docstring states the ordering requirement, and a new test pins the failure. The example is executed by rhiza's README validator, so it cannot drift.

## Verification

- `make test` — 69 passed (up from 63), 450/450 statements, coverage gate held at 100%
- `make fmt` — green
- `make typecheck` — `ty` and `mypy --strict` clean across 26 modules
- `make deptry` — no dependency issues
- `make security` — clean, and no `Test in comment` warnings
- `make docs-coverage` — 272/272 at a 100% bar
- `make rhiza-test` — 40 passed, README code block executed and compared against its `result` block

**One note:** `check_test_layout.py` still exits 1 on this branch, because the `[tool.check_test_layout]` opt-out for #562 is on `document-test-layout-optout` (PR #568) and not yet merged. Not a regression from these commits — this branch adds one more orphan (`test_public_api.py`) that the opt-out covers. Merging #568 first, or after, resolves it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)