### PR TITLE
Drop problem serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,59 +85,43 @@ objective: 0.9354
 weights: [0.75 0.25 0.   0.  ]
 ```
 
-### Reusing a compiled problem across sessions
+### Reusing a built problem
 
-A built problem can be written to disk and loaded back, so the cvxpy
-compilation survives a restart. Serialize **before** solving: a solved problem
-holds a live solver handle that cannot be pickled.
+The problems are parameterized (DPP-compliant), so a single built problem can be
+re-solved with fresh data. Build once, then `update` and `solve` in a loop — the
+cvxpy canonicalization is paid for on the first solve and reused afterwards.
 
 ```python
-import tempfile
-from pathlib import Path
+problem = MinVar(assets=4).build()  # build once
 
-from cvxmarkowitz import deserialize
-
-data = {
-    D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
-    D.LOWER_BOUND_ASSETS: np.zeros(2),
-    D.UPPER_BOUND_ASSETS: np.ones(2),
-    D.VOLA_UNCERTAINTY: np.zeros(2),
-}
-
-with tempfile.TemporaryDirectory() as tmp:
-    path = Path(tmp) / "problem.pkl"
-
-    # Build and store the compiled problem without solving it.
-    MinVar(assets=4).build().serialize(path)
-
-    # Later, or in another process: load it and solve.
-    recovered = deserialize(path, trusted=True)
-    recovered.update(**data)
-    print("recovered objective:", round(recovered.solve(), 4))
+for correlation in (0.0, 0.5, 0.9):
+    problem.update(
+        **{
+            D.CHOLESKY: cholesky(np.array([[1.0, correlation], [correlation, 2.0]])),
+            D.LOWER_BOUND_ASSETS: np.zeros(2),
+            D.UPPER_BOUND_ASSETS: np.ones(2),
+            D.VOLA_UNCERTAINTY: np.zeros(2),
+        }
+    )
+    print(f"rho={correlation}: objective={problem.solve():.4f}")
 ```
 
 ```result
-recovered objective: 0.9354
+rho=0.0: objective=0.8165
+rho=0.5: objective=0.9354
+rho=0.9: objective=0.9958
 ```
-
-> **`deserialize` executes arbitrary code.** It is `pickle.load` underneath, so
-> loading a file is equivalent to running whatever that file's author chose to
-> run. The `trusted=True` flag is a deliberate gate, not a formality: without it
-> the call raises `CvxTrustError` rather than unpickling. Only ever pass it for a
-> file you produced yourself with `serialize`, and never for one received over a
-> network or from an untrusted source.
 
 ## Errors
 
 Everything the package raises derives from `CvxError`, so a single
-`except CvxError` still catches all of it. Three subclasses separate the failure
+`except CvxError` still catches all of it. Two subclasses separate the failure
 modes that want different handling:
 
 | Error | Raised when | Retry helps? |
 |---|---|---|
 | `CvxDataError` | required data is missing, or shapes disagree | yes, with corrected input |
 | `CvxSolverError` | the solver returned a non-optimal status | no — try another solver or relax the problem |
-| `CvxTrustError` | `deserialize` was called without `trusted=True` | no — it is a security guard |
 
 ## Development
 

--- a/src/cvxmarkowitz/__init__.py
+++ b/src/cvxmarkowitz/__init__.py
@@ -19,22 +19,18 @@ from .builder import Builder as Builder
 from .cvxerror import CvxDataError as CvxDataError
 from .cvxerror import CvxError as CvxError
 from .cvxerror import CvxSolverError as CvxSolverError
-from .cvxerror import CvxTrustError as CvxTrustError
 from .portfolios.max_sharpe import MaxSharpe as MaxSharpe
 from .portfolios.min_var import MinVar as MinVar
 from .portfolios.soft_risk import SoftRisk as SoftRisk
 from .problem import Problem as Problem
-from .problem import deserialize as deserialize
 
 __all__ = [
     "Builder",
     "CvxDataError",
     "CvxError",
     "CvxSolverError",
-    "CvxTrustError",
     "MaxSharpe",
     "MinVar",
     "Problem",
     "SoftRisk",
-    "deserialize",
 ]

--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -25,14 +25,14 @@ from cvxmarkowitz.model import Model
 from cvxmarkowitz.models.bounds import Bounds
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
-from cvxmarkowitz.problem import Problem, deserialize
+from cvxmarkowitz.problem import Problem
 from cvxmarkowitz.risk.factor.factor import FactorModel
 from cvxmarkowitz.risk.sample.sample import SampleCovariance
 from cvxmarkowitz.types import Parameter, Variables
 
-# Re-exported for backwards compatibility: ``deserialize``/``Problem`` moved to
+# Re-exported for backwards compatibility: ``Problem`` moved to
 # cvxmarkowitz.problem, ``CvxError`` lives in cvxmarkowitz.cvxerror.
-__all__ = ["Builder", "CvxError", "Problem", "deserialize"]
+__all__ = ["Builder", "CvxError", "Problem"]
 
 
 @dataclass(frozen=True)

--- a/src/cvxmarkowitz/cvxerror.py
+++ b/src/cvxmarkowitz/cvxerror.py
@@ -39,12 +39,3 @@ class CvxSolverError(CvxError):
     solve to optimality. Retrying with the same input will not help;
     another solver or a relaxed formulation might.
     """
-
-
-class CvxTrustError(CvxError):
-    """A trust boundary was crossed without explicit consent.
-
-    Raised when :func:`~cvxmarkowitz.problem.deserialize` is called without
-    ``trusted=True``. This is a security guard, not a transient failure —
-    catching it to retry with ``trusted=True`` defeats its purpose.
-    """

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -11,67 +11,21 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-"""The built problem container and its (de)serialization round-trip."""
+"""The built problem container returned by :meth:`Builder.build`."""
 
 from __future__ import annotations
 
-import pickle  # nosec B403
 from collections.abc import Generator
 from dataclasses import dataclass, field
-from os import PathLike
 from typing import Any
 
 import cvxpy as cp
 import numpy as np
 
-from cvxmarkowitz.cvxerror import CvxDataError, CvxSolverError, CvxTrustError
+from cvxmarkowitz.cvxerror import CvxDataError, CvxSolverError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
-from cvxmarkowitz.types import File, Matrix, Parameter, Variables
-
-
-def deserialize(
-    problem_file: str | bytes | PathLike[str] | PathLike[bytes] | int,
-    *,
-    trusted: bool = False,
-) -> Any:
-    """Load a previously serialized Markowitz problem from disk.
-
-    .. warning::
-
-        This uses :func:`pickle.load`, which executes arbitrary code while
-        unpickling. Only ever call this on files you produced yourself with
-        :meth:`Problem.serialize`. Never deserialize a file received from an
-        untrusted or unauthenticated source — doing so is equivalent to
-        running that source's code on your machine.
-
-    To make that trust boundary explicit, deserialization is opt-in: you must
-    pass ``trusted=True`` to confirm the file is one you produced yourself.
-    Calling without it raises :class:`~cvxmarkowitz.cvxerror.CvxError` rather
-    than silently unpickling.
-
-    Args:
-        problem_file: Path to the pickle file created by `Problem.serialize`.
-        trusted: Must be set to ``True`` to confirm the file originates from a
-            trusted source. Defaults to ``False``, which refuses to load.
-
-    Returns:
-        The deserialized `Problem` instance.
-
-    Raises:
-        CvxError: If ``trusted`` is not explicitly set to ``True``.
-    """
-    if not trusted:
-        raise CvxTrustError(  # noqa: TRY003
-            "Refusing to deserialize: pickle.load executes arbitrary code. "
-            "Pass trusted=True only for a file you produced yourself with "
-            "Problem.serialize()."
-        )
-    # pickle is the intended format for round-tripping a built problem. The trust
-    # boundary is guarded by the trusted flag above; the input is assumed to be a
-    # self-produced serialize() file. Suppressions are on the call itself below.
-    with open(problem_file, "rb") as infile:
-        return pickle.load(infile)  # nosec B301  # noqa: S301
+from cvxmarkowitz.types import Matrix, Parameter, Variables
 
 
 @dataclass(frozen=True)
@@ -178,17 +132,3 @@ class Problem:
     def factor_weights(self) -> Matrix:
         """Return the optimal factor weights as a numpy array."""
         return np.array(self.variables[D.FACTOR_WEIGHTS].value)
-
-    def serialize(self, problem_file: File) -> None:
-        """Pickle this problem to disk for later reuse with `deserialize`.
-
-        Call this before :meth:`solve`. Solving attaches a live solver handle to
-        the underlying cvxpy problem, and that handle is not picklable — a
-        solved problem raises ``TypeError: cannot pickle 'builtins.DefaultSolver'
-        object`` here.
-
-        Args:
-            problem_file: Destination path for the pickle file.
-        """
-        with open(problem_file, "wb") as outfile:
-            pickle.dump(self, outfile)

--- a/src/cvxmarkowitz/types.py
+++ b/src/cvxmarkowitz/types.py
@@ -13,14 +13,12 @@
 #    limitations under the License.
 """Common type aliases used across the Markowitz package."""
 
-from os import PathLike
 from typing import TypeAlias
 
 import cvxpy as cp
 import numpy as np
 import numpy.typing as npt
 
-File = str | bytes | PathLike[str]
 Parameter = dict[str, cp.Parameter]
 Variables = dict[str, cp.Variable]
 Constraints = dict[str, cp.Constraint]

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -1,14 +1,11 @@
-"""Tests for serialization/deserialization of Markowitz problems."""
+"""Tests for the built Problem container."""
 
 import dataclasses
 
 import cvxpy as cp
-import numpy as np
 import pytest
-from cvx.linalg import cholesky, rand_cov
 
-from cvxmarkowitz import CvxError, CvxTrustError, MinVar, deserialize
-from cvxmarkowitz.names import DataNames as D
+from cvxmarkowitz import MinVar
 
 
 def test_problem_data():
@@ -25,77 +22,3 @@ def test_problem_is_frozen():
     problem = MinVar(assets=10).build()
     with pytest.raises(dataclasses.FrozenInstanceError):
         problem.problem = None
-
-
-def test_deserialize_requires_trusted(tmp_path):
-    """Deserialize refuses to unpickle unless trusted=True is passed.
-
-    Args:
-        tmp_path: Pytest temporary directory for storing the pickle file.
-    """
-    problem = MinVar(assets=10).build()
-    path = tmp_path / "problem.pkl"
-    problem.serialize(path)
-
-    with pytest.raises(CvxTrustError, match="trusted=True"):
-        deserialize(path)
-
-    # The default is False, so a positional/implicit call is also refused.
-    with pytest.raises(CvxTrustError):
-        deserialize(path, trusted=False)
-
-    # The refusal is still catchable via the package's base error.
-    with pytest.raises(CvxError):
-        deserialize(path)
-
-
-def test_serialize_after_solve_is_unsupported(tmp_path):
-    """A solved problem cannot be pickled: the solver handle is not picklable.
-
-    Args:
-        tmp_path: Pytest temporary directory for storing the pickle file.
-    """
-    problem = MinVar(assets=2).build()
-    problem.update(
-        **{
-            D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
-            D.LOWER_BOUND_ASSETS: np.zeros(2),
-            D.UPPER_BOUND_ASSETS: np.ones(2),
-            D.VOLA_UNCERTAINTY: np.zeros(2),
-        }
-    )
-    problem.solve()
-
-    with pytest.raises(TypeError, match="pickle"):
-        problem.serialize(tmp_path / "solved.pkl")
-
-
-def test_serialize(tmp_path):
-    """Serialize a problem, deserialize it, and compare resulting weights.
-
-    Args:
-        tmp_path: Pytest temporary directory for storing the pickle file.
-    """
-    problem = MinVar(assets=10).build()
-    problem.serialize(tmp_path / "problem.pkl")
-    problem_recovered = deserialize(tmp_path / "problem.pkl", trusted=True)
-
-    covariance = rand_cov(10)
-
-    input_data = {
-        D.CHOLESKY: cholesky(covariance),
-        D.LOWER_BOUND_ASSETS: np.zeros(10),
-        D.UPPER_BOUND_ASSETS: np.ones(10),
-        D.VOLA_UNCERTAINTY: np.zeros(10),
-    }
-
-    problem.update(**input_data)
-
-    problem.solve()
-    sol1 = problem.weights
-
-    problem_recovered.update(**input_data)
-    problem_recovered.solve()
-    sol2 = problem_recovered.weights
-
-    np.testing.assert_array_equal(sol1, sol2)

--- a/tests/test_markowitz/test_public_api.py
+++ b/tests/test_markowitz/test_public_api.py
@@ -23,12 +23,10 @@ def test_documented_entry_points_are_exported():
         "CvxDataError",
         "CvxError",
         "CvxSolverError",
-        "CvxTrustError",
         "MaxSharpe",
         "MinVar",
         "Problem",
         "SoftRisk",
-        "deserialize",
     }
     assert expected <= set(cvxmarkowitz.__all__)
 
@@ -38,7 +36,6 @@ def test_error_subclasses_derive_from_the_base():
     for subclass in (
         cvxmarkowitz.CvxDataError,
         cvxmarkowitz.CvxSolverError,
-        cvxmarkowitz.CvxTrustError,
     ):
         assert issubclass(subclass, cvxmarkowitz.CvxError)
 


### PR DESCRIPTION
## Why

`Problem.serialize` / `deserialize` arrived in July 2023 (`b8b9e0e`) as `cvx/cli/aux/problem.py` — a helper for the since-removed `cvx.cli` package, alongside `io.py` and `json.py`. The pattern it served was the CLI split: one invocation builds a problem and writes a `.pkl`, a later invocation loads it and solves with fresh data. That CLI is gone, and nothing in the package has called these since.

The documented rationale doesn't hold up either. The README claimed "the cvxpy compilation survives a restart." It doesn't — canonicalization lands in `problem._cache`, which is only populated by the first `solve`, and serializing had to happen *before* solving because a solved problem carries an unpicklable solver handle (`test_serialize_after_solve_is_unsupported` asserted exactly that). So the pickle could only ever hold the un-canonicalized expression DAG. Measured on a 500-asset `MinVar`:

```text
build 0.003s     dump 0.001s (1969 KB)     load 0.000s
cache after load: {'key': None, 'solving_chain': None, 'param_prog': None, ...}
```

A 3 ms saving for a 2 MB file, with canonicalization redone on first solve regardless. What it cost was the `pickle.load` arbitrary-code-execution surface, and with it a `trusted=True` gate, a `CvxTrustError` in the error taxonomy, four bandit/ruff suppressions and a README warning block — a real share of the package's security surface.

The reuse that *does* work needs no disk: the problems are DPP-parameterized, so you build once and then `update`/`solve` in-process as often as you like.

## What changed

- **`problem.py`** — removed `deserialize` and `Problem.serialize`, the `pickle` import and its `nosec B403` / `nosec B301` / `noqa: S301` suppressions, and the now-unused `PathLike` / `File` imports.
- **`cvxerror.py`** — removed `CvxTrustError`. It existed solely to guard `deserialize`, so it had no remaining raiser.
- **`__init__.py`** — dropped `deserialize` and `CvxTrustError` from the imports and `__all__`.
- **`builder.py`** — dropped the `deserialize` back-compat re-export.
- **`types.py`** — dropped the `File` alias; `serialize` was its only consumer.
- **tests** — removed `test_deserialize_requires_trusted`, `test_serialize_after_solve_is_unsupported` and `test_serialize`; updated the expected export set and error-subclass loop in `test_public_api.py`.
- **README** — replaced "Reusing a compiled problem across sessions" and its pickle warning with "Reusing a built problem", which shows build-once then `update`/`solve` across three correlation values. Dropped the `CvxTrustError` table row ("Three subclasses" → "Two").

## Verification

- `pytest` → 66 passed
- `pytest .rhiza/tests/test_readme_validation.py .rhiza/tests/test_readme.py` → 11 passed. This is what executes the new README snippet and diffs it against the `result` block, so the documented numbers (`0.8165 / 0.9354 / 0.9958`) are measured, not guessed.
- `ruff check` clean, `mypy` clean on 26 source files, all pre-commit hooks pass (including bandit and interrogate).
- `.rhiza/tests/test_docstrings.py` can't be collected locally (`No module named 'dotenv'`) — pre-existing and unrelated; it runs in CI.

## Note for the reviewer

This is a **breaking public-API change**: `Problem.serialize`, `cvxmarkowitz.deserialize` and `CvxTrustError` all disappear. `CvxTrustError` was public only as of #569, but `builder.py` had a comment explicitly keeping `deserialize` for backwards compatibility, so external callers may exist. It wants a minor-version bump; the commit is typed `refactor!:` with a `BREAKING CHANGE:` trailer so git-cliff picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
