### PR TITLE
fix: close the error-taxonomy holes and API-clarity gaps from #571-#577

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,26 @@ constraints. Only once we trigger the build() method do we construct
 the problem and compile it.
 
 For injecting values for data and parameters into the problem,
-we use the [update](src/cvxmarkowitz/problem.py#L84) method.
+we use the [update](src/cvxmarkowitz/problem.py) method. It overwrites the
+parameter values **in place** and returns `None` — there is only ever one
+problem, which is precisely what lets CVXPY reuse the cached compilation.
+
+The builder picks a risk model for you: a `FactorModel` when you pass `factors`,
+a `SampleCovariance` otherwise. To use a different one — `CVar`, say — pass it in
+under `ModelName.RISK` and the builder keeps yours instead of defaulting:
+
+```python
+from cvxmarkowitz import MinVar
+from cvxmarkowitz.names import ModelName as M
+from cvxmarkowitz.risk import CVar
+
+builder = MinVar(assets=14, model={M.RISK: CVar(alpha=0.95, rows=50, assets=14)})
+print(type(builder.risk).__name__)
+```
+
+```result
+CVar
+```
 
 ## Installation
 
@@ -121,7 +140,11 @@ modes that want different handling:
 | Error | Raised when | Retry helps? |
 |---|---|---|
 | `CvxDataError` | required data is missing, or shapes disagree | yes, with corrected input |
+| `CvxBuildError` | the assembled problem is not DPP-compliant | no — the formulation has to change |
 | `CvxSolverError` | the solver returned a non-optimal status | no — try another solver or relax the problem |
+
+The `CvxBuildError` check is a raise rather than an `assert`, so it still fires
+under `python -O`.
 
 ## Development
 
@@ -143,3 +166,21 @@ make marimo
 ```
 
 will install and start marimo.
+
+## experiments
+
+`experiments/` holds standalone research scripts — backtests and the figures
+behind the talks — not part of the installed package. They pull in the `dev`
+dependency group (`yfinance`, `loguru`, `cvxsimulator`, `tinycta`, `plotly`),
+so run them against the full development environment:
+
+```bash
+make install
+uv run --group dev python experiments/minRisk1.py
+```
+
+They are deliberately outside the quality gates: `make typecheck`,
+`make docs-coverage`, `make deptry` and `make security` all scope to `src/`, and
+the coverage gate scopes to `tests/`. Only `make fmt` reaches them, since
+pre-commit runs repo-wide. Treat them as scratch work — if something here earns
+a stability guarantee, it belongs in `src/cvxmarkowitz/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "cvxpy-base>=1.9.2",
     "numpy>=2.4.6",
     "clarabel>=0.11.1",
-    "cvx-linalg==0.9.6"
 ]
 
 [project.urls]
@@ -30,6 +29,10 @@ Homepage = "https://github.com/cvxgrp/cvxmarkowitz"
 Repository = "https://github.com/cvxgrp/cvxmarkowitz"
 
 [dependency-groups]
+# cvx-linalg is a test/example helper, not a runtime dependency: nothing under
+# src/ imports it. It builds Cholesky factors and random covariances for the
+# tests, the README example and the experiments/ scripts, so the library's
+# consumers should not be made to install it.
 dev = [
     "fire>=0.7.1",
     "mock>=5.2.0",
@@ -38,12 +41,14 @@ dev = [
     "tinycta>=0.14.0",
     "plotly>=6.9.0",
     "cvxsimulator>=1.5.1",
+    "cvx-linalg>=0.9.6",
     "scikit-learn>=1.9.0",
     "marimo>=0.23.16",
     "pytest>=9.1.1",
 ]
 test = [
     "pytest>=9.1.1",
+    "cvx-linalg>=0.9.6",
 ]
 
 [build-system]
@@ -70,7 +75,10 @@ marimo = "marimo"
 pytest = "pytest"
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["clarabel", "cvx-linalg"]
+# clarabel is declared but never imported on purpose: it is a solver backend that
+# cvxpy resolves by name at runtime. Nothing else belongs here -- a dependency
+# that src/ does not import is either a backend like this one or misplaced.
+DEP002 = ["clarabel"]
 
 # Tests here are grouped by the behaviour they exercise rather than mirrored
 # one-to-one onto source modules: tests/test_markowitz/ covers src/cvxmarkowitz/
@@ -88,6 +96,26 @@ reason = "Tests are grouped by behaviour under tests/test_markowitz/; per-module
 # invisible to static analysis, so `mypy --strict` reports spurious
 # attr-defined / no-any-return / no-untyped-call errors at every cvxpy call
 # site. Treat cvxpy as untyped so those expressions resolve to Any.
+#
+# What this costs, stated plainly: under this override every cvxpy symbol is Any
+# to mypy, including the classes on our own public surface (cp.Expression,
+# cp.Variable, cp.Parameter, cp.Problem, cp.Minimize/Maximize). So mypy's "no
+# issues found" covers the dataclass plumbing and the numpy edges, NOT the
+# optimisation semantics -- do not read it as more than that.
+#
+# What covers the rest: `ty`, which runs in the same `make typecheck` target and
+# does resolve cvxpy's real types (verified: it rejects an attribute typo on a
+# cp.Variable and rejects returning a cp.Variable where cp.Problem is declared,
+# and it is what flags the Parameter.value operator issue in soft_risk.py). The
+# two checkers are complementary here, which is why both run. Removing `ty` from
+# the target on the grounds that "mypy --strict already passes" would silently
+# drop all cvxpy type checking.
+#
+# Narrowing this to `disable_error_code` on cvxpy instead was tried and does not
+# work: per-module overrides apply to errors reported *in* that module, while
+# these 34 errors are reported in our files. Scoping the disables to
+# cvxmarkowitz.* would work, but it trades attr-defined and operator across all
+# of our own code for coverage `ty` already provides properly.
 [[tool.mypy.overrides]]
 module = ["cvxpy", "cvxpy.*"]
 follow_imports = "skip"

--- a/src/cvxmarkowitz/__init__.py
+++ b/src/cvxmarkowitz/__init__.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from .builder import Builder as Builder
+from .cvxerror import CvxBuildError as CvxBuildError
 from .cvxerror import CvxDataError as CvxDataError
 from .cvxerror import CvxError as CvxError
 from .cvxerror import CvxSolverError as CvxSolverError
@@ -26,6 +27,7 @@ from .problem import Problem as Problem
 
 __all__ = [
     "Builder",
+    "CvxBuildError",
     "CvxDataError",
     "CvxError",
     "CvxSolverError",

--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 
 import cvxpy as cp
 
-from cvxmarkowitz.cvxerror import CvxError
+from cvxmarkowitz.cvxerror import CvxBuildError, CvxDataError, CvxError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.models.bounds import Bounds
 from cvxmarkowitz.names import DataNames as D
@@ -42,8 +42,12 @@ class Builder(ABC):
     Attributes:
         assets: Number of asset weights to optimize.
         factors: Optional number of factors; if provided, a FactorModel is used,
-            otherwise a SampleCovariance risk model is configured.
-        model: Mapping of model components (e.g., bounds, risk) by name.
+            otherwise a SampleCovariance risk model is configured. Ignored for the
+            choice of risk model when one is injected via `model`, but still
+            controls which variables and bounds are created.
+        model: Mapping of model components (e.g., bounds, risk) by name. Pass an
+            entry under `ModelName.RISK` to supply your own risk model instead of
+            the `factors`-based default -- see `__post_init__`.
         constraints: Mapping of named cvxpy constraints added during build.
         variables: Mapping of problem variables (weights, factor weights, etc.).
         parameter: Mapping of cvxpy Parameters used by the builder/models.
@@ -57,17 +61,23 @@ class Builder(ABC):
     parameter: Parameter = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Initialize default risk model, variables, and bounds.
+        """Initialize the risk model, variables, and bounds.
 
-        Selects a factor-based or sample-covariance risk model depending on
-        `factors`, creates the corresponding variables (weights and, if
-        applicable, factor weights and their absolute values), and registers
-        per-asset and/or per-factor bound models.
+        Creates the variables (weights and, if `factors` is given, factor weights
+        and their absolute values) and registers the per-asset and/or per-factor
+        bound models.
+
+        The risk model is only defaulted when the caller did not supply one.
+        Passing `model={ModelName.RISK: my_model}` to the constructor keeps that
+        model, which is how risk models outside the two defaults -- `CVar`, say --
+        are used with a builder:
+
+            MinVar(assets=10, model={M.RISK: CVar(assets=10, rows=100)})
+
+        With no entry under `ModelName.RISK`, the default is a `FactorModel` when
+        `factors` is set and a `SampleCovariance` otherwise.
         """
-        # pick the correct risk model
         if self.factors is not None:
-            self.model[M.RISK] = FactorModel(assets=self.assets, factors=self.factors)
-
             # add variable for factor weights
             self.variables[D.FACTOR_WEIGHTS] = cp.Variable(self.factors, name=D.FACTOR_WEIGHTS)
             # add bounds for factor weights
@@ -75,10 +85,16 @@ class Builder(ABC):
             # add variable for absolute factor weights
             self.variables[D._ABS] = cp.Variable(self.factors, name=D._ABS, nonneg=True)
 
+            # pick the default risk model, unless the caller injected one
+            if M.RISK not in self.model:
+                self.model[M.RISK] = FactorModel(assets=self.assets, factors=self.factors)
+
         else:
-            self.model[M.RISK] = SampleCovariance(assets=self.assets)
             # add variable for absolute weights
             self.variables[D._ABS] = cp.Variable(self.assets, name=D._ABS, nonneg=True)
+
+            if M.RISK not in self.model:
+                self.model[M.RISK] = SampleCovariance(assets=self.assets)
 
         # Note that for the SampleCovariance model the factor_weights are None.
         # They are only included for the harmony of the interfaces for both models.
@@ -93,13 +109,26 @@ class Builder(ABC):
         """Return the objective function."""
 
     def build(self) -> Problem:
-        """Build the cvxpy problem."""
+        """Build the cvxpy problem.
+
+        Raises:
+            CvxBuildError: If the assembled problem is not DPP-compliant. This is
+                checked with a raise rather than an `assert` on purpose: `assert`
+                is stripped under `python -O`, and DPP compliance is the invariant
+                the whole caching story rests on.
+        """
         for name_model, model in self.model.items():
             for name_constraint, constraint in model.constraints(self.variables).items():
                 self.constraints[f"{name_model}_{name_constraint}"] = constraint
 
         problem = cp.Problem(self.objective, list(self.constraints.values()))
-        assert problem.is_dpp(), "Problem is not DPP"  # noqa: S101
+
+        if not problem.is_dpp():
+            raise CvxBuildError(  # noqa: TRY003
+                "The assembled problem is not DPP-compliant, so cvxpy cannot cache "
+                "its canonicalization. Check the objective and the constraints for "
+                "expressions that are not affine in the parameters."
+            )
 
         return Problem(problem=problem, model=self.model)
 
@@ -117,7 +146,14 @@ class Builder(ABC):
     def factor_weights(self) -> cp.Variable:
         """Return the factor-weight variable.
 
-        Note: Only present when a factor risk model is used; accessing this
-        property without factors configured will raise a KeyError.
+        Raises:
+            CvxDataError: If the builder was constructed without `factors`, in
+                which case there is no factor-weight variable to return.
         """
-        return self.variables[D.FACTOR_WEIGHTS]
+        try:
+            return self.variables[D.FACTOR_WEIGHTS]
+        except KeyError as err:
+            raise CvxDataError(  # noqa: TRY003
+                "No factor weights: this builder was constructed without 'factors'. "
+                "Pass factors=<number of factors> to use a factor risk model."
+            ) from err

--- a/src/cvxmarkowitz/cvxerror.py
+++ b/src/cvxmarkowitz/cvxerror.py
@@ -39,3 +39,16 @@ class CvxSolverError(CvxError):
     solve to optimality. Retrying with the same input will not help;
     another solver or a relaxed formulation might.
     """
+
+
+class CvxBuildError(CvxError):
+    """The assembled problem does not satisfy the package's construction rules.
+
+    Raised by :meth:`Builder.build` when the problem it assembled is not
+    :abbr:`DPP (disciplined parametrized programming)`-compliant. The whole
+    point of building a parametrized problem here is that cvxpy caches the
+    canonicalization and reuses it on later solves, and only DPP-compliant
+    problems get that treatment -- so a non-DPP problem is a formulation bug,
+    not a data problem. Retrying will not help; the objective or the
+    constraints have to change.
+    """

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -35,8 +35,30 @@ class Problem:
     problem: cp.Problem
     model: dict[str, Model] = field(default_factory=dict)
 
-    def update(self, **kwargs: Matrix) -> Problem:
-        """Update the problem."""
+    def update(self, **kwargs: Matrix) -> None:
+        """Overwrite the parameter values of every model, **in place**.
+
+        This mutates the problem rather than returning a new one. `frozen=True`
+        on this dataclass only stops attribute rebinding; the `model` mapping and
+        the cvxpy Parameters it holds stay mutable, and that is deliberate --
+        writing new values into the same compiled problem is exactly what lets
+        cvxpy reuse its cached canonicalization across solves:
+
+            problem = MinVar(assets=4).build()   # compile once
+            for data in datasets:
+                problem.update(**data)           # overwrite in place
+                problem.solve()
+
+        Consequently there is only ever one problem. Two `update` calls against
+        the same object do not yield two independently parametrized problems --
+        the second overwrites the first. Call `build()` again for that.
+
+        Returns `None` (like `Model.update`) so the in-place semantics are
+        visible at the call site.
+
+        Raises:
+            CvxDataError: If any model is missing data for one of its parameters.
+        """
         for name, model in self.model.items():
             for key in model.data:
                 if key not in kwargs:
@@ -47,8 +69,6 @@ class Problem:
             # the models can be prepared to deal with data that has not
             # exactly the correct shape.
             model.update(**kwargs)
-
-        return self
 
     def solve(self, solver: str = cp.CLARABEL, **kwargs: Any) -> float:
         """Solve the problem."""
@@ -130,5 +150,15 @@ class Problem:
 
     @property
     def factor_weights(self) -> Matrix:
-        """Return the optimal factor weights as a numpy array."""
-        return np.array(self.variables[D.FACTOR_WEIGHTS].value)
+        """Return the optimal factor weights as a numpy array.
+
+        Raises:
+            CvxDataError: If the problem was built without a factor risk model,
+                in which case there is no factor-weight variable.
+        """
+        try:
+            return np.array(self.variables[D.FACTOR_WEIGHTS].value)
+        except KeyError as err:
+            raise CvxDataError(  # noqa: TRY003
+                "No factor weights: this problem was built without 'factors'."
+            ) from err

--- a/src/cvxmarkowitz/risk/factor/factor.py
+++ b/src/cvxmarkowitz/risk/factor/factor.py
@@ -68,14 +68,24 @@ class FactorModel(Model):
         )
 
     def estimate(self, variables: Variables) -> cp.Expression:
-        """Compute the total variance."""
-        var_residual = self._residual_risk(variables)
-        var_systematic = self._systematic_risk(variables)
+        """Compute the total risk as the norm of its systematic and residual parts.
+
+        The two parts are available on their own via `systematic_risk` and
+        `residual_risk`; this is their Euclidean combination.
+        """
+        var_residual = self.residual_risk(variables)
+        var_systematic = self.systematic_risk(variables)
 
         return cp.norm2(cp.vstack([var_systematic, var_residual]))
 
-    def _residual_risk(self, variables: Variables) -> cp.Expression:
-        """Return the L2 norm of idiosyncratic and its uncertainty contributions."""
+    def residual_risk(self, variables: Variables) -> cp.Expression:
+        """Return the asset-specific (idiosyncratic) part of the risk.
+
+        The L2 norm of the idiosyncratic volatility contribution and its
+        uncertainty contribution. Part of the model's public surface: the
+        systematic/residual split is what a factor model is for, and
+        `estimate` is the norm of this and `systematic_risk`.
+        """
         return cp.norm2(
             cp.hstack(
                 [
@@ -88,8 +98,12 @@ class FactorModel(Model):
             )
         )
 
-    def _systematic_risk(self, variables: Variables) -> cp.Expression:
-        """Return the L2 norm of systematic and its uncertainty contributions."""
+    def systematic_risk(self, variables: Variables) -> cp.Expression:
+        """Return the factor-driven (systematic) part of the risk.
+
+        The L2 norm of the systematic volatility contribution and its
+        uncertainty contribution. See `residual_risk` for the counterpart.
+        """
         return cp.norm2(
             cp.hstack(
                 [

--- a/tests/test_markowitz/test_builder.py
+++ b/tests/test_markowitz/test_builder.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 import cvxpy as cp
 import numpy as np
 import pytest
 
-from cvxmarkowitz import Builder, CvxDataError, CvxSolverError
+from cvxmarkowitz import Builder, CvxBuildError, CvxDataError, CvxSolverError
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
@@ -22,6 +25,27 @@ class DummyBuilder(Builder):
     def objective(self):
         """Return a trivial objective to exercise the builder wiring in tests."""
         return cp.Maximize(0.0 + 0.0 * self.risk.estimate(self.variables))
+
+    def __post_init__(self):
+        """Initialize base components and add a unit budget constraint for tests."""
+        super().__post_init__()
+        self.constraints[C.BUDGET] = cp.sum(self.weights) == 1.0
+
+
+@dataclass(frozen=True)
+class NotDppBuilder(Builder):
+    """A Builder whose objective is DCP-compliant but deliberately not DPP.
+
+    The product of two parameters is not affine in the parameters, so cvxpy
+    cannot cache the canonicalization -- exactly the case `build` must reject.
+    """
+
+    @property
+    def objective(self):
+        """Return an objective that multiplies two parameters together."""
+        left = cp.Parameter(nonneg=True, name="left")
+        right = cp.Parameter(nonneg=True, name="right")
+        return cp.Minimize(left * right * cp.sum(self.weights))
 
     def __post_init__(self):
         """Initialize base components and add a unit budget constraint for tests."""
@@ -47,7 +71,8 @@ def test_dummy():
             D.UPPER_BOUND_ASSETS: np.array([1.0]),
             D.VOLA_UNCERTAINTY: np.zeros(1),
         }
-    ).solve(solver=cp.CLARABEL)
+    )
+    problem.solve(solver=cp.CLARABEL)
 
     assert np.allclose(dict(problem.data)[(M.RISK, "chol")].value, np.eye(1))
 
@@ -90,3 +115,36 @@ def test_builder_risk():
     """The builder.risk property should reference the risk model in model dict."""
     builder = DummyBuilder(assets=1)
     assert builder.risk == builder.model[M.RISK]
+
+
+def test_non_dpp_problem_raises_cvx_build_error():
+    """A non-DPP problem must be rejected with a CvxError, not an AssertionError."""
+    builder = NotDppBuilder(assets=2)
+
+    with pytest.raises(CvxBuildError, match="not DPP-compliant"):
+        builder.build()
+
+
+def test_the_dpp_check_survives_optimized_mode():
+    """The DPP guard must be a raise, not an assert.
+
+    `assert` is stripped under `python -O`, which would silently remove the one
+    invariant the parameter-caching design depends on. Run the check in a real
+    optimized interpreter rather than trusting the source to stay assert-free.
+    """
+    program = (
+        "from tests.test_markowitz.test_builder import NotDppBuilder\n"
+        "from cvxmarkowitz import CvxBuildError\n"
+        "try:\n"
+        "    NotDppBuilder(assets=2).build()\n"
+        "except CvxBuildError:\n"
+        "    print('raised')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", program],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parents[2],
+        check=True,
+    )
+    assert result.stdout.strip() == "raised"

--- a/tests/test_markowitz/test_portfolios/test_max_sharpe.py
+++ b/tests/test_markowitz/test_portfolios/test_max_sharpe.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky
 
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
@@ -39,8 +40,8 @@ def test_constraints(builder):
 
 
 def test_factor_weights(builder):
-    """Accessing factor weights without a factor model should raise KeyError."""
-    with pytest.raises(KeyError):
+    """Accessing factor weights without a factor model should raise CvxDataError."""
+    with pytest.raises(CvxDataError, match="without 'factors'"):
         _ = builder.factor_weights
 
 

--- a/tests/test_markowitz/test_portfolios/test_min_var.py
+++ b/tests/test_markowitz/test_portfolios/test_min_var.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky
 
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.names import ConstraintName as C
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
@@ -39,8 +40,8 @@ def test_constraints(builder):
 
 
 def test_factor_weights(builder):
-    """Accessing factor weights without factor model should raise KeyError."""
-    with pytest.raises(KeyError):
+    """Accessing factor weights without a factor model should raise CvxDataError."""
+    with pytest.raises(CvxDataError, match="without 'factors'"):
         _ = builder.factor_weights
 
 

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -3,9 +3,22 @@
 import dataclasses
 
 import cvxpy as cp
+import numpy as np
 import pytest
+from cvx.linalg import cholesky
 
-from cvxmarkowitz import MinVar
+from cvxmarkowitz import CvxDataError, MinVar
+from cvxmarkowitz.names import DataNames as D
+
+
+def _data(correlation: float) -> dict[str, np.ndarray]:
+    """Return a complete data payload for a two-asset MinVar problem."""
+    return {
+        D.CHOLESKY: cholesky(np.array([[1.0, correlation], [correlation, 2.0]])),
+        D.LOWER_BOUND_ASSETS: np.zeros(2),
+        D.UPPER_BOUND_ASSETS: np.ones(2),
+        D.VOLA_UNCERTAINTY: np.zeros(2),
+    }
 
 
 def test_problem_data():
@@ -22,3 +35,42 @@ def test_problem_is_frozen():
     problem = MinVar(assets=10).build()
     with pytest.raises(dataclasses.FrozenInstanceError):
         problem.problem = None
+
+
+def test_update_returns_none():
+    """update() mutates in place, so it returns None rather than a Problem."""
+    problem = MinVar(assets=2).build()
+    assert problem.update(**_data(0.5)) is None
+
+
+def test_update_overwrites_in_place():
+    """A second update replaces the first: there is only ever one problem.
+
+    `frozen=True` stops attribute rebinding but not mutation of the parameter
+    values, and that is deliberate -- it is what lets cvxpy reuse the cached
+    canonicalization. This pins the aliasing so a future switch to copy
+    semantics cannot happen silently.
+    """
+    problem = MinVar(assets=2).build()
+
+    problem.update(**_data(0.0))
+    first = problem.solve()
+
+    problem.update(**_data(0.9))
+    second = problem.solve()
+
+    # the same object now answers with the second dataset
+    assert first != pytest.approx(second)
+    assert second == pytest.approx(0.9958, abs=1e-4)
+
+    # a genuinely independent problem needs a fresh build
+    other = MinVar(assets=2).build()
+    other.update(**_data(0.0))
+    assert other.solve() == pytest.approx(first)
+
+
+def test_factor_weights_without_factors():
+    """Asking a non-factor problem for factor weights raises CvxDataError."""
+    problem = MinVar(assets=2).build()
+    with pytest.raises(CvxDataError, match="without 'factors'"):
+        _ = problem.factor_weights

--- a/tests/test_markowitz/test_public_api.py
+++ b/tests/test_markowitz/test_public_api.py
@@ -20,6 +20,7 @@ def test_documented_entry_points_are_exported():
     """The builders, the built problem and the error type are reachable directly."""
     expected = {
         "Builder",
+        "CvxBuildError",
         "CvxDataError",
         "CvxError",
         "CvxSolverError",
@@ -34,10 +35,26 @@ def test_documented_entry_points_are_exported():
 def test_error_subclasses_derive_from_the_base():
     """Catching CvxError still catches every specific error the package raises."""
     for subclass in (
+        cvxmarkowitz.CvxBuildError,
         cvxmarkowitz.CvxDataError,
         cvxmarkowitz.CvxSolverError,
     ):
         assert issubclass(subclass, cvxmarkowitz.CvxError)
+
+
+def test_every_exported_exception_derives_from_cvxerror():
+    """The README's promise, enforced: no exported error sits outside the tree.
+
+    Guards against a new exception being exported without being folded into the
+    hierarchy, which is what would quietly falsify "except CvxError catches all
+    of it" in the README.
+    """
+    exported = [getattr(cvxmarkowitz, name) for name in cvxmarkowitz.__all__]
+    errors = [obj for obj in exported if isinstance(obj, type) and issubclass(obj, BaseException)]
+
+    assert errors, "expected at least one exported exception"
+    for error in errors:
+        assert issubclass(error, cvxmarkowitz.CvxError), f"{error.__name__} is not a CvxError"
 
 
 def test_build_returns_the_exported_problem_type():

--- a/tests/test_markowitz/test_risk/test_cvar/test_cvar.py
+++ b/tests/test_markowitz/test_risk/test_cvar/test_cvar.py
@@ -21,12 +21,11 @@ def test_estimate_risk(solver):
 
     np.random.seed(42)
 
-    # define the problem
-    builder = MinVar(assets=14)
+    # Inject the risk model through the constructor. The builder only defaults
+    # M.RISK when the caller did not supply one, so no SampleCovariance is built.
+    builder = MinVar(assets=14, model={M.RISK: model})
 
-    # overwrite the risk model
-    builder.model[M.RISK] = model
-
+    assert builder.risk is model
     assert M.BOUND_ASSETS in builder.model
 
     problem = builder.build()
@@ -53,3 +52,20 @@ def test_estimate_risk(solver):
 
     problem.solve(solver=solver)
     assert problem.value == pytest.approx(0.4355917, abs=1e-5)
+
+
+def test_injected_risk_model_replaces_the_default():
+    """A risk model passed to the constructor is kept, not overwritten."""
+    model = CVar(alpha=0.95, rows=50, assets=14)
+    builder = MinVar(assets=14, model={M.RISK: model})
+
+    assert builder.model[M.RISK] is model
+    # the sample-covariance default would have registered a cholesky parameter
+    assert D.CHOLESKY not in builder.risk.data
+    assert D.RETURNS in builder.risk.data
+
+
+def test_default_risk_model_is_used_when_none_is_given():
+    """Without an injected model the factors-based default still applies."""
+    assert D.CHOLESKY in MinVar(assets=14).risk.data
+    assert D.EXPOSURE in MinVar(assets=14, factors=3).risk.data

--- a/tests/test_markowitz/test_risk/test_factor/test_factor.py
+++ b/tests/test_markowitz/test_risk/test_factor/test_factor.py
@@ -150,12 +150,46 @@ def test_factor_mini():
     residual = np.sqrt(0.03)
     systematic = np.sqrt(1.098725)
 
-    assert model._residual_risk(variables=variables).value == pytest.approx(residual)
-    assert model._systematic_risk(variables=variables).value == pytest.approx(systematic)
+    assert model.residual_risk(variables=variables).value == pytest.approx(residual)
+    assert model.systematic_risk(variables=variables).value == pytest.approx(systematic)
 
     total = np.linalg.norm(np.array([residual, systematic]))
 
     assert model.estimate(variables=variables).value == pytest.approx(total)
+
+
+def test_estimate_decomposes_into_its_two_parts():
+    """estimate() is the Euclidean norm of the systematic and residual parts.
+
+    Asserted through the public surface only, so the decomposition can be
+    reformulated internally as long as the relationship holds.
+    """
+    model = FactorModel(assets=3, factors=2)
+
+    variables = {
+        D.WEIGHTS: cp.Variable(3),
+        D.FACTOR_WEIGHTS: cp.Variable(2),
+        D._ABS: cp.Variable(2),
+    }
+
+    model.update(
+        **{
+            D.CHOLESKY: np.eye(2),
+            D.EXPOSURE: np.array([[1, 0, 1], [1, 0.5, 1]]),
+            D.IDIOSYNCRATIC_VOLA: np.array([0.1, 0.1, 0.1]),
+            D.IDIOSYNCRATIC_VOLA_UNCERTAINTY: np.array([0.3, 0.3, 0.3]),
+            D.SYSTEMATIC_VOLA_UNCERTAINTY: np.array([0.2, 0.1]),
+        }
+    )
+
+    variables[D.WEIGHTS].value = np.array([0.5, 0.1, 0.2])
+    variables[D.FACTOR_WEIGHTS] = model.data[D.EXPOSURE] @ variables[D.WEIGHTS]
+    variables[D._ABS] = cp.abs(variables[D.FACTOR_WEIGHTS])
+
+    residual = model.residual_risk(variables=variables).value
+    systematic = model.systematic_risk(variables=variables).value
+
+    assert model.estimate(variables=variables).value == pytest.approx(np.linalg.norm([residual, systematic]))
 
 
 def test_missing_key(factor_model):

--- a/uv.lock
+++ b/uv.lock
@@ -303,13 +303,13 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "clarabel" },
-    { name = "cvx-linalg" },
     { name = "cvxpy-base" },
     { name = "numpy" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "cvx-linalg" },
     { name = "cvxsimulator" },
     { name = "fire" },
     { name = "loguru" },
@@ -322,19 +322,20 @@ dev = [
     { name = "yfinance" },
 ]
 test = [
+    { name = "cvx-linalg" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "clarabel", specifier = ">=0.11.1" },
-    { name = "cvx-linalg", specifier = "==0.9.6" },
     { name = "cvxpy-base", specifier = ">=1.9.2" },
     { name = "numpy", specifier = ">=2.4.6" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cvx-linalg", specifier = ">=0.9.6" },
     { name = "cvxsimulator", specifier = ">=1.5.1" },
     { name = "fire", specifier = ">=0.7.1" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -346,7 +347,10 @@ dev = [
     { name = "tinycta", specifier = ">=0.14.0" },
     { name = "yfinance", specifier = ">=1.5.2" },
 ]
-test = [{ name = "pytest", specifier = ">=9.1.1" }]
+test = [
+    { name = "cvx-linalg", specifier = ">=0.9.6" },
+    { name = "pytest", specifier = ">=9.1.1" },
+]
 
 [[package]]
 name = "cvxpy-base"


### PR DESCRIPTION
Addresses all seven findings from the `/rhiza:quality` assessment.

Closes #571
Closes #572
Closes #573
Closes #574
Closes #575
Closes #576
Closes #577

## Gates

All seven template gates plus test-layout parity pass. Coverage holds at the
repo's self-raised 100% bar: **445/445 statements**, up from 435, with the suite
growing from 66 to **75 tests**.

| Gate | Result |
|---|---|
| `make fmt` | PASS (21 hooks) |
| `make typecheck` | PASS — `ty` clean, `mypy --strict` clean over 26 modules |
| `make docs-coverage` | PASS — 100.0% against a 100.0% minimum |
| `make deptry` / `make deps` | PASS |
| `make security` | PASS |
| `make rhiza-test` | PASS — 40 tests, incl. README code-block validation |
| `make test` | PASS — 75 passed, 100.00% coverage |
| test-layout parity | PASS |

## #571 — the CvxError taxonomy holes

`Builder.build` guarded DPP compliance with `assert problem.is_dpp()`. `assert`
is stripped under `python -O`, so in an optimised interpreter the invariant the
entire parameter-caching design rests on simply vanished. It now raises a new
`CvxBuildError`.

`Builder.factor_weights` documented a bare `KeyError` escaping a public
property. `Problem.factor_weights` had the identical defect one class over —
not named in the issue, but the same contract violation — so both now raise
`CvxDataError` with an actionable message.

Two tests rather than one, because the interesting failure modes are different:

- `test_every_exported_exception_derives_from_cvxerror` asserts the property
  generically over `__all__`, so a future exported exception cannot quietly
  falsify the README's "everything derives from `CvxError`".
- `test_the_dpp_check_survives_optimized_mode` spawns a real `python -O`
  subprocess. Grepping the source for `assert` would pass today and rot the
  moment someone reintroduces one; running the optimised interpreter cannot.

## #572 — cvx-linalg was a runtime dependency

`cvx-linalg==0.9.6` sat in `[project].dependencies` and is imported nowhere
under `src/` — only by tests, `experiments/` and the README example. It was
also the manifest's only exact pin, so every consumer installed a package it
never imports at a version that could conflict with their own resolution.

Moved to the `test` and `dev` groups and dropped from the `DEP002` ignore list,
which now covers only `clarabel` (a genuine case: a solver backend cvxpy
resolves by name at runtime).

Verified the way that actually matters — a runtime-only install into a fresh
venv:

```
cvx-linalg present: False
objective: 0.9354
```

matching the README's documented result.

## #573 — CVar could never be a Builder's risk model

`__post_init__` assigned `model[M.RISK]` unconditionally, so even a caller
passing `model={M.RISK: CVar(...)}` had it overwritten. `CVar` is public,
exported from `risk/__init__.py`, and fully covered — but unreachable through
any builder.

The default is now applied only when the caller supplied none:

```python
builder = MinVar(assets=14, model={M.RISK: CVar(alpha=0.95, rows=50, assets=14)})
```

Corroborating evidence that this was the right read: the existing CVar test was
working around it by mutating `builder.model[M.RISK]` *after* construction. That
workaround is gone.

## #574 — Problem.update mutated while returning self

Annotated `-> Problem` on a `frozen=True` dataclass, mutating in place and
returning `self`. Three separate signals pointed a reader at copy semantics, and
`p.update(d1)` / `p.update(d2)` returning the same aliased object is a quiet way
to solve with the wrong dataset.

Now returns `None`, consistent with `Model.update`, with the in-place contract
documented and the aliasing pinned by a test so a future switch to copy
semantics cannot happen silently. Only one call site chained off the return
value.

## #575 — stale README anchor, undocumented experiments/

`README.md` linked `problem.py#L84` for `update`, which lives at line 38. The
line fragment is dropped rather than corrected, so it cannot rot again — the
plain-file links in the same paragraph never did.

`experiments/` (six scripts) is now documented: what it is, which dependency
group it needs, how to run one, and that it sits outside `make typecheck` /
`docs-coverage` / `deptry` / `security` deliberately.

## #576 — resolved as documentation, having tested the alternative

The issue's preferred fix does not work. A per-module `disable_error_code` on
`cvxpy` applies to errors reported *in cvxpy*, whereas all 34 are reported in
our files. Scoping the disables to `cvxmarkowitz.*` does work, but trades
`attr-defined` and `operator` across our own code.

Before paying that, I checked whether the coverage was actually missing — and it
is not. `ty` runs in the same `make typecheck` target and resolves cvxpy's real
types. Verified directly: it rejects an attribute typo on a `cp.Variable`, and
rejects returning a `cp.Variable` where `cp.Problem` is declared. It is also
what flags the `Parameter.value` operator issue in `soft_risk.py`.

So the gate was never blind here; only mypy's half was, and `ty` covers exactly
what mypy loses. The override stays, and the comment now records what mypy's
pass does and does not cover — plus a warning that dropping `ty` because
"mypy --strict already passes" would remove all cvxpy type checking. That is
option 3 from the issue, grounded in a verified claim rather than a caveat.

## #577 — tests asserted private helpers

Promoted `FactorModel._residual_risk` / `_systematic_risk` to public
`residual_risk` / `systematic_risk` (option 2 — the systematic/residual split is
what a factor model is *for*, and it is something callers legitimately want),
with docstrings. Added a test asserting the decomposition relationship purely
through `estimate`, so the internals can be reformulated as long as the property
holds.

## Notes

- Three `experiments/` scripts still carry their own `assert problem.is_dpp()`,
  now redundant since `build()` enforces it. Left alone: scratch scripts,
  explicitly outside the gates.
- `soft_risk.py:63` has a genuine `Parameter.value` optionality issue that `ty`
  already flags with an existing `ty: ignore`. Pre-existing, not touched here.
- `CvxBuildError` is a new export, so `__all__` and the README error table both
  grew an entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
