### PR TITLE
fix: close the error-taxonomy hole and naming gaps from #579-#582

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+## What this is
+
+`cvxmarkowitz` builds [Markowitz](https://en.wikipedia.org/wiki/Harry_Markowitz)
+portfolio-construction problems on top of [cvxpy](https://www.cvxpy.org). The
+design goal is stated in `README.md` and shapes everything else: a problem is
+**compiled once and re-solved many times** with fresh data. That requires every
+assembled problem to be
+[DPP](https://www.cvxpy.org/tutorial/advanced/index.html#disciplined-parametrized-programming)-compliant,
+so cvxpy can cache its canonicalization across solves.
+
+Two consequences that are easy to violate by accident:
+
+- **`Problem.update` mutates in place and returns `None`.** There is only ever
+  one problem; a second `update` overwrites the first. `Problem` is
+  `frozen=True`, which stops attribute rebinding but deliberately not mutation
+  of the cvxpy Parameters it holds. Do not change this to copy semantics.
+- **`Builder.build` raises `CvxBuildError` on a non-DPP problem — a `raise`, not
+  an `assert`.** `assert` is stripped under `python -O`, and DPP compliance is
+  the invariant the whole caching story rests on.
+  `tests/test_markowitz/test_builder.py` pins this by running the check in a
+  real `python -O` subprocess.
+
+## Repository layout and ownership
+
+This repo is **rhiza-managed**: `.rhiza/template.yml` points at
+`jebel-quant/rhiza` (currently `v1.3.3`) and a large part of the development
+infrastructure is synced from there. Knowing which half you are editing matters,
+because a change to a template-owned file is reverted by the next
+`/rhiza:update`.
+
+**Locally owned — edit freely:**
+
+| Path | What |
+| --- | --- |
+| `src/cvxmarkowitz/` | the library |
+| `tests/` | the test suite (except `tests/test_rhiza_packaging.py`) |
+| `experiments/` | standalone research scripts, not part of the package |
+| `pyproject.toml` | manifest, tool config, dependency groups |
+| `README.md`, `mkdocs.yml` | project docs and site nav |
+| `.rhiza/template.yml` | which template ref this repo tracks |
+| `.clusterfuzzlite/`, `copyright.txt`, `portfolio.png` | local extras |
+
+**Template-owned — fix upstream, not here:** `.github/**`, everything under
+`.rhiza/` except `template.yml`, all of `docs/`, plus `ruff.toml`, `pytest.ini`,
+`.pre-commit-config.yaml`, `.bandit`, `.editorconfig`, `.gitignore`,
+`.python-version`, `cliff.toml`, `LICENSE`, `SECURITY.md` and
+`tests/test_rhiza_packaging.py`.
+
+The authoritative list is the `files:` block of `.rhiza/template.lock` — 68
+paths, machine-generated, do not hand-edit.
+
+**The documented extension points** are the exception to the rule above. These
+are template-delivered but merged rather than replaced, so local edits survive a
+sync:
+
+- `Makefile` — a thin shim that sets overrides and then `include`s
+  `.rhiza/rhiza.mk`. This is where `COVERAGE_FAIL_UNDER = 100` lives, raising the
+  template's default of 90. Keep it small.
+- `.rhiza/make.d/custom-task.mk` and `custom-env.mk` — repo-specific targets.
+- `local.mk` — developer-local, gitignored, optional.
+
+## Commands
+
+Always go through `make`; the flags, thresholds and exclusions live in the
+targets, so invoking the tools directly measures something else.
+
+| Command | What it runs |
+| --- | --- |
+| `make install` | create `.venv` from `uv.lock`, install pre-commit hooks |
+| `make test` | pytest with the 100% coverage gate |
+| `make fmt` | the full pre-commit suite (ruff, markdownlint, bandit, actionlint, …) |
+| `make typecheck` | `ty` **and** `mypy --strict` over `src/` |
+| `make docs-coverage` | interrogate, at a 100% minimum |
+| `make deps` | deptry (`make deptry` is the deprecated spelling) |
+| `make security` | bandit |
+| `make rhiza-test` | the template's own bundled tests under `.rhiza/tests/` |
+| `make all` | everything CI runs |
+| `make help` | the full target list |
+
+## Conventions
+
+**Both type checkers matter.** `pyproject.toml` treats cvxpy as untyped for
+mypy, because its functional atoms are exported dynamically and `mypy --strict`
+reports spurious errors at every call site. The cost is that every cvxpy symbol
+is `Any` to mypy — so mypy's "no issues found" covers the dataclass plumbing and
+the numpy edges, *not* the optimisation semantics. `ty` covers those. Do not
+drop `ty` from `make typecheck` on the grounds that mypy passes.
+
+**Use the constants in `names.py`.** `DataNames`, `ModelName`, `ConstraintName`
+and `ParameterName` exist so that a key is spelled once. Indexing `data`,
+`parameter` or `kwargs` with a string literal that has a constant is a bug even
+when the strings happen to agree today: presence checks iterate the constants,
+so a later rename splits the two paths silently.
+
+**A model must declare every keyword its `update` consumes.** `Problem.update`
+guards inputs by walking `Model.keywords`, which defaults to the keys of
+`data`. If a model reads a keyword backed by `parameter` instead — as
+`ExpectedReturns` does for `mu_uncertainty` — it **must** override `keywords`,
+or a caller who omits that keyword gets a bare `KeyError` rather than a
+`CvxDataError`.
+
+**Everything raised derives from `CvxError`.** `CvxDataError`, `CvxBuildError`
+and `CvxSolverError` split the failure modes by whether retrying helps; the
+table in `README.md` is the contract. `tests/test_markowitz/test_public_api.py`
+enforces that no exported exception escapes the tree.
+
+**The risk package owns its own defaults.** `Builder` calls
+`cvxmarkowitz.risk.default_risk_model` rather than naming `FactorModel` or
+`SampleCovariance` itself, so adding a default is a change to `risk/`, not to
+the abstract base class. `Bounds` is still imported directly by `builder.py` on
+purpose — it is unconditional structure, not a choice among alternatives.
+
+**Both gates are at 100% and should stay there.** Test coverage
+(`COVERAGE_FAIL_UNDER = 100`) and docstring coverage (interrogate). New code
+needs tests and docstrings in the same change.
+
+**Tests are grouped by behaviour, not mirrored onto modules.** `tests/` does not
+follow the one-test-file-per-source-module convention; the opt-out is recorded
+in `[tool.check_test_layout]` in `pyproject.toml`, with per-module coverage
+guaranteed by the 100% gate instead. The suite uses no mocks — keep it that way,
+and assert behaviour rather than implementation.
+
+**`experiments/` is scratch work.** It sits outside every gate except `make fmt`
+(`typecheck`, `docs-coverage`, `deps` and `security` all scope to `src/`). If
+something there earns a stability guarantee it belongs in `src/cvxmarkowitz/`.
+
+## Release
+
+Versioning is driven by `bump-my-version`, configured in `pyproject.toml` to
+read and rewrite `[project].version` directly. The release workflow commits and
+tags itself, so `commit` and `tag` are both `false` there.
+
+The package is **not published to PyPI**. The guard is the literal comment
+`# Private :: Do Not Upload` in `pyproject.toml` — `.github/workflows/rhiza_release.yml`
+matches it with a plain `grep -R` over the file, so it works despite not being a
+real classifier. **Do not delete that line** as tidy-up; it is load-bearing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cvxmarkowitz"
 version = "0.0.1"
-description = "Markowitz"
+description = "Build DPP-compliant Markowitz portfolio problems with cvxpy once, then re-solve them with fresh data"
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"},
     {name = "Kasper Johansson"},
     {name = "Philipp Schiele"},
@@ -14,8 +14,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
-#authors = ["Thomas Schmelzer", "Kasper Johansson", "Philipp Schiele", "Stephen Boyd"]
-#readme = "README.md"
 requires-python = ">=3.11"
 # Private :: Do Not Upload (prevents rhiza_release.yml from publishing to PyPI)
 dependencies = [

--- a/src/cvxmarkowitz/builder.py
+++ b/src/cvxmarkowitz/builder.py
@@ -22,12 +22,16 @@ import cvxpy as cp
 
 from cvxmarkowitz.cvxerror import CvxBuildError, CvxDataError, CvxError
 from cvxmarkowitz.model import Model
+
+# `Bounds` is imported concretely on purpose: it is not a default being chosen
+# among alternatives but part of what a Builder unconditionally is, so putting
+# it behind a selector would be indirection with nothing to select. The risk
+# model *is* a choice, and `default_risk_model` owns it -- see cvxmarkowitz.risk.
 from cvxmarkowitz.models.bounds import Bounds
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
 from cvxmarkowitz.problem import Problem
-from cvxmarkowitz.risk.factor.factor import FactorModel
-from cvxmarkowitz.risk.sample.sample import SampleCovariance
+from cvxmarkowitz.risk import default_risk_model
 from cvxmarkowitz.types import Parameter, Variables
 
 # Re-exported for backwards compatibility: ``Problem`` moved to
@@ -74,8 +78,9 @@ class Builder(ABC):
 
             MinVar(assets=10, model={M.RISK: CVar(assets=10, rows=100)})
 
-        With no entry under `ModelName.RISK`, the default is a `FactorModel` when
-        `factors` is set and a `SampleCovariance` otherwise.
+        With no entry under `ModelName.RISK`, `cvxmarkowitz.risk.default_risk_model`
+        picks one: a `FactorModel` when `factors` is set, a `SampleCovariance`
+        otherwise.
         """
         if self.factors is not None:
             # add variable for factor weights
@@ -85,16 +90,13 @@ class Builder(ABC):
             # add variable for absolute factor weights
             self.variables[D._ABS] = cp.Variable(self.factors, name=D._ABS, nonneg=True)
 
-            # pick the default risk model, unless the caller injected one
-            if M.RISK not in self.model:
-                self.model[M.RISK] = FactorModel(assets=self.assets, factors=self.factors)
-
         else:
             # add variable for absolute weights
             self.variables[D._ABS] = cp.Variable(self.assets, name=D._ABS, nonneg=True)
 
-            if M.RISK not in self.model:
-                self.model[M.RISK] = SampleCovariance(assets=self.assets)
+        # pick the default risk model, unless the caller injected one
+        if M.RISK not in self.model:
+            self.model[M.RISK] = default_risk_model(assets=self.assets, factors=self.factors)
 
         # Note that for the SampleCovariance model the factor_weights are None.
         # They are only included for the harmony of the interfaces for both models.

--- a/src/cvxmarkowitz/model.py
+++ b/src/cvxmarkowitz/model.py
@@ -31,6 +31,27 @@ class Model(ABC):
     parameter: Parameter = field(default_factory=dict)
     data: Parameter = field(default_factory=dict)
 
+    @property
+    def keywords(self) -> tuple[str, ...]:
+        """Return the keyword names this model's `update` consumes.
+
+        `Problem.update` checks these against the keywords it was handed before
+        any value is written, so that a missing one is reported as a
+        `CvxDataError` rather than escaping as whatever the model's own
+        `kwargs[...]` lookup happens to raise.
+
+        The default is the keys of `data`, which is where a model registers the
+        cvxpy Parameters it fills from keyword arguments. **Override it whenever
+        `update` reads a keyword that `data` does not back** -- otherwise the
+        check cannot see that keyword and a caller who omits it gets a bare
+        `KeyError`, which is outside the `CvxError` tree the package promises.
+        `ExpectedReturns` is the one such model today.
+
+        Returns a tuple rather than a set so the key named in the error message
+        follows the insertion order of `data` instead of set iteration order.
+        """
+        return tuple(self.data)
+
     @abstractmethod
     def estimate(self, variables: Variables) -> cp.Expression:
         """Estimate the variance given the portfolio weights."""

--- a/src/cvxmarkowitz/models/expected_returns.py
+++ b/src/cvxmarkowitz/models/expected_returns.py
@@ -40,12 +40,23 @@ class ExpectedReturns(Model):
         )
 
         # Robust return estimate
-        self.parameter["mu_uncertainty"] = cp.Parameter(
+        self.parameter[D.MU_UNCERTAINTY] = cp.Parameter(
             shape=self.assets,
-            name="mu_uncertainty",
+            name=D.MU_UNCERTAINTY,
             value=np.zeros(self.assets),
             nonneg=True,
         )
+
+    @property
+    def keywords(self) -> tuple[str, ...]:
+        """Return the keywords `update` consumes, including `mu_uncertainty`.
+
+        `mu_uncertainty` is registered in `parameter` rather than `data`, so the
+        base implementation -- the keys of `data` -- would not list it, and
+        `Problem.update` would let a caller omit it and then fail with a
+        `KeyError` from `update` below.
+        """
+        return (*self.data, D.MU_UNCERTAINTY)
 
     def estimate(self, variables: Variables) -> cp.Expression:
         """Return robust expected return w^T mu - mu_uncertainty^T |w|.
@@ -56,21 +67,21 @@ class ExpectedReturns(Model):
         Returns:
             A CVXPY expression for the robust expected return.
         """
-        return self.data[D.MU] @ variables[D.WEIGHTS] - self.parameter["mu_uncertainty"] @ cp.abs(variables[D.WEIGHTS])
+        return self.data[D.MU] @ variables[D.WEIGHTS] - self.parameter[D.MU_UNCERTAINTY] @ cp.abs(variables[D.WEIGHTS])
 
     def update(self, **kwargs: Matrix) -> None:
         """Update expected returns and their uncertainty bounds.
 
         Expected keyword arguments:
-            D.MU: Vector of expected returns.
+            mu: Vector of expected returns.
             mu_uncertainty: Nonnegative vector with element-wise uncertainty.
         """
         exp_returns = kwargs[D.MU]
         self.data[D.MU].value = fill_vector(num=self.assets, x=exp_returns)
 
         # Robust return estimate
-        uncertainty = kwargs["mu_uncertainty"]
+        uncertainty = kwargs[D.MU_UNCERTAINTY]
         if not uncertainty.shape[0] == exp_returns.shape[0]:
             raise CvxDataError("Mismatch in length for mu and mu_uncertainty")  # noqa: TRY003
 
-        self.parameter["mu_uncertainty"].value = fill_vector(num=self.assets, x=uncertainty)
+        self.parameter[D.MU_UNCERTAINTY].value = fill_vector(num=self.assets, x=uncertainty)

--- a/src/cvxmarkowitz/models/trading_costs.py
+++ b/src/cvxmarkowitz/models/trading_costs.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
+from cvxmarkowitz.names import ParameterName as P
 from cvxmarkowitz.types import Matrix, Variables
 from cvxmarkowitz.utils.fill import fill_vector
 
@@ -32,10 +33,11 @@ class TradingCosts(Model):
 
     def __post_init__(self) -> None:
         """Initialize trading cost parameters and previous-weights cache."""
-        self.parameter["power"] = cp.Parameter(shape=(), name="power", value=1.0)
+        self.parameter[P.POWER] = cp.Parameter(shape=(), name=P.POWER, value=1.0)
 
-        # initial weights before rebalancing
-        self.data["weights"] = cp.Parameter(shape=self.assets, name="weights", value=np.zeros(self.assets))
+        # initial weights before rebalancing -- keyed by D.WEIGHTS, the same name
+        # the decision variable uses, since it is the previous value of it.
+        self.data[D.WEIGHTS] = cp.Parameter(shape=self.assets, name=D.WEIGHTS, value=np.zeros(self.assets))
 
     def estimate(self, variables: Variables) -> cp.Expression:
         """Estimate trading costs for a rebalance.
@@ -49,8 +51,8 @@ class TradingCosts(Model):
         """
         return cp.sum(
             cp.power(
-                cp.abs(variables[D.WEIGHTS] - self.data["weights"]),
-                p=self.parameter["power"],
+                cp.abs(variables[D.WEIGHTS] - self.data[D.WEIGHTS]),
+                p=self.parameter[P.POWER],
             )
         )
 
@@ -60,4 +62,4 @@ class TradingCosts(Model):
         Expected keyword arguments:
             weights: Vector of previous weights used as the trading baseline.
         """
-        self.data["weights"].value = fill_vector(num=self.assets, x=kwargs["weights"])
+        self.data[D.WEIGHTS].value = fill_vector(num=self.assets, x=kwargs[D.WEIGHTS])

--- a/src/cvxmarkowitz/names.py
+++ b/src/cvxmarkowitz/names.py
@@ -73,3 +73,4 @@ class ParameterName:
     SIGMA_MAX = "sigma_max"
     OMEGA = "omega"
     SIGMA_TARGET = "sigma_target"
+    POWER = "power"

--- a/src/cvxmarkowitz/problem.py
+++ b/src/cvxmarkowitz/problem.py
@@ -60,7 +60,10 @@ class Problem:
             CvxDataError: If any model is missing data for one of its parameters.
         """
         for name, model in self.model.items():
-            for key in model.data:
+            # `Model.keywords`, not `model.data`: a model may consume a keyword
+            # that `data` does not back (see `ExpectedReturns.keywords`), and
+            # checking `data` alone let those through to a bare KeyError.
+            for key in model.keywords:
                 if key not in kwargs:
                     raise CvxDataError(f"Missing data for {key} in model {name}")  # noqa: TRY003
 

--- a/src/cvxmarkowitz/risk/__init__.py
+++ b/src/cvxmarkowitz/risk/__init__.py
@@ -15,8 +15,39 @@
 
 from __future__ import annotations
 
+from cvxmarkowitz.model import Model
+
 from .cvar.cvar import CVar as CVar
 from .factor.factor import FactorModel as FactorModel
 from .sample.sample import SampleCovariance as SampleCovariance
 
-__all__ = ["CVar", "FactorModel", "SampleCovariance"]
+__all__ = ["CVar", "FactorModel", "SampleCovariance", "default_risk_model"]
+
+
+def default_risk_model(assets: int, factors: int | None) -> Model:
+    """Return the risk model a `Builder` uses when the caller injects none.
+
+    A `FactorModel` when `factors` is given, a `SampleCovariance` otherwise.
+
+    This rule lives here rather than in `Builder` so that the risk package owns
+    the choice among its own members: adding a further default is a change to
+    this subpackage, not to the abstract base class every builder inherits
+    from. `Builder` therefore imports this function instead of the concrete
+    model classes.
+
+    Note what this does *not* do: it cannot default to `CVar`, which needs
+    `rows` and `alpha` that a builder does not carry. `CVar` stays an injected
+    model -- pass `model={ModelName.RISK: CVar(...)}` to the builder, which
+    skips this function entirely.
+
+    Args:
+        assets: Number of assets the model is sized for.
+        factors: Number of factors, or None for a non-factor problem.
+
+    Returns:
+        A `Model` instance to register under `ModelName.RISK`.
+    """
+    if factors is None:
+        return SampleCovariance(assets=assets)
+
+    return FactorModel(assets=assets, factors=factors)

--- a/src/cvxmarkowitz/risk/factor/factor.py
+++ b/src/cvxmarkowitz/risk/factor/factor.py
@@ -125,7 +125,7 @@ class FactorModel(Model):
         """
         self._validate(**kwargs)
 
-        self.data[D.EXPOSURE].value = fill_matrix(rows=self.factors, cols=self.assets, x=kwargs["exposure"])
+        self.data[D.EXPOSURE].value = fill_matrix(rows=self.factors, cols=self.assets, x=kwargs[D.EXPOSURE])
         self.data[D.IDIOSYNCRATIC_VOLA].value = fill_vector(num=self.assets, x=kwargs[D.IDIOSYNCRATIC_VOLA])
         self.data[D.CHOLESKY].value = fill_matrix(rows=self.factors, cols=self.factors, x=kwargs[D.CHOLESKY])
 

--- a/tests/test_markowitz/test_models/test_expected_returns.py
+++ b/tests/test_markowitz/test_models/test_expected_returns.py
@@ -18,11 +18,11 @@ def test_expected_returns():
     """Estimate plain expected return with zero uncertainty and padding behavior."""
     assets = 3
     model = ExpectedReturns(assets=assets)
-    model.update(**{D.MU: np.array([0.1, 0.2]), "mu_uncertainty": np.array([0.0, 0.0])})
+    model.update(**{D.MU: np.array([0.1, 0.2]), D.MU_UNCERTAINTY: np.array([0.0, 0.0])})
 
     # expected returns not explicitly set are zero
     assert model.data[D.MU].value == pytest.approx(np.array([0.1, 0.2, 0.0]))
-    assert model.parameter["mu_uncertainty"].value == pytest.approx(np.array([0.0, 0.0, 0.0]))
+    assert model.parameter[D.MU_UNCERTAINTY].value == pytest.approx(np.array([0.0, 0.0, 0.0]))
 
     weights = cp.Variable(assets)
     weights.value = np.array([1.0, 1.0, 2.0])
@@ -42,8 +42,8 @@ def test_expected_returns_robust():
     model.update(mu=np.array([0.1, 0.2]), mu_uncertainty=np.array([0.01, 0.03]))
 
     # expected returns not explicitly set are zero
-    assert model.data["mu"].value == pytest.approx(np.array([0.1, 0.2, 0.0]))
-    assert model.parameter["mu_uncertainty"].value == pytest.approx(np.array([0.01, 0.03, 0.0]))
+    assert model.data[D.MU].value == pytest.approx(np.array([0.1, 0.2, 0.0]))
+    assert model.parameter[D.MU_UNCERTAINTY].value == pytest.approx(np.array([0.01, 0.03, 0.0]))
 
     weights = cp.Variable(assets)
     weights.value = np.array([1.0, 1.0, 2.0])
@@ -62,3 +62,18 @@ def test_mismatch():
     model = ExpectedReturns(assets=assets)
     with pytest.raises(CvxDataError):
         model.update(mu=np.array([0.1, 0.2]), mu_uncertainty=np.array([0.03]))
+
+
+def test_keywords_declares_the_parameter_backed_input():
+    """`keywords` lists mu_uncertainty, which `data` on its own does not.
+
+    This is the override that lets `Problem.update` guard a keyword held in
+    `parameter`. Asserting `data` does *not* contain it keeps the test honest:
+    were mu_uncertainty ever moved into `data`, the override would become
+    redundant rather than silently wrong, and this test would say so.
+    """
+    model = ExpectedReturns(assets=3)
+
+    assert set(model.keywords) == {D.MU, D.MU_UNCERTAINTY}
+    assert D.MU_UNCERTAINTY not in model.data
+    assert D.MU_UNCERTAINTY in model.parameter

--- a/tests/test_markowitz/test_portfolios/test_problem.py
+++ b/tests/test_markowitz/test_portfolios/test_problem.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from cvx.linalg import cholesky
 
-from cvxmarkowitz import CvxDataError, MinVar
+from cvxmarkowitz import CvxDataError, MaxSharpe, MinVar
 from cvxmarkowitz.names import DataNames as D
 
 
@@ -17,6 +17,23 @@ def _data(correlation: float) -> dict[str, np.ndarray]:
         D.CHOLESKY: cholesky(np.array([[1.0, correlation], [correlation, 2.0]])),
         D.LOWER_BOUND_ASSETS: np.zeros(2),
         D.UPPER_BOUND_ASSETS: np.ones(2),
+        D.VOLA_UNCERTAINTY: np.zeros(2),
+    }
+
+
+def _max_sharpe_data() -> dict[str, np.ndarray]:
+    """Return a complete data payload for a two-asset MaxSharpe problem.
+
+    MaxSharpe is the case that matters here because it carries an
+    `ExpectedReturns` model, the only one with a keyword held in `parameter`
+    rather than `data`.
+    """
+    return {
+        D.CHOLESKY: cholesky(np.array([[1.0, 0.5], [0.5, 2.0]])),
+        D.LOWER_BOUND_ASSETS: np.zeros(2),
+        D.UPPER_BOUND_ASSETS: np.ones(2),
+        D.MU: np.array([0.25, 0.30]),
+        D.MU_UNCERTAINTY: np.zeros(2),
         D.VOLA_UNCERTAINTY: np.zeros(2),
     }
 
@@ -74,3 +91,41 @@ def test_factor_weights_without_factors():
     problem = MinVar(assets=2).build()
     with pytest.raises(CvxDataError, match="without 'factors'"):
         _ = problem.factor_weights
+
+
+def test_missing_parameter_backed_keyword_raises_cvx_data_error():
+    """Omitting `mu_uncertainty` raises CvxDataError, not a bare KeyError.
+
+    `ExpectedReturns` keeps `mu_uncertainty` in `model.parameter` rather than
+    `model.data`. `Problem.update` used to build its presence check from
+    `model.data` alone, so this call fell through to `kwargs["mu_uncertainty"]`
+    inside the model and raised `KeyError` -- outside the `CvxError` tree the
+    README promises `except CvxError` catches in full.
+    """
+    problem = MaxSharpe(assets=2).build()
+    payload = _max_sharpe_data()
+    del payload[D.MU_UNCERTAINTY]
+
+    with pytest.raises(CvxDataError, match=D.MU_UNCERTAINTY):
+        problem.update(**payload)
+
+
+def test_dropping_any_required_keyword_raises_cvx_data_error():
+    """Every keyword a model declares is guarded, not just the ones in `data`.
+
+    The general form of the test above. It walks `Model.keywords` instead of
+    naming keys, so a model that later starts consuming a keyword without
+    declaring it is caught here rather than raising `KeyError` at a caller.
+    """
+    problem = MaxSharpe(assets=2).build()
+    required = {key for model in problem.model.values() for key in model.keywords}
+
+    # the parameter-backed keyword must be among them; that is the whole point
+    assert D.MU_UNCERTAINTY in required
+    assert required == set(_max_sharpe_data())
+
+    for omitted in sorted(required):
+        payload = _max_sharpe_data()
+        del payload[omitted]
+        with pytest.raises(CvxDataError, match="Missing data for"):
+            problem.update(**payload)

--- a/tests/test_markowitz/test_risk/test_defaults.py
+++ b/tests/test_markowitz/test_risk/test_defaults.py
@@ -1,0 +1,39 @@
+"""Tests for the default risk-model selection owned by cvxmarkowitz.risk."""
+
+from __future__ import annotations
+
+from cvxmarkowitz import MinVar
+from cvxmarkowitz.names import ModelName as M
+from cvxmarkowitz.risk import CVar, FactorModel, SampleCovariance, default_risk_model
+
+
+def test_default_without_factors_is_sample_covariance():
+    """A non-factor problem defaults to the sample covariance model."""
+    model = default_risk_model(assets=5, factors=None)
+    assert isinstance(model, SampleCovariance)
+    assert model.assets == 5
+
+
+def test_default_with_factors_is_factor_model():
+    """Passing factors selects the factor model, sized for both dimensions."""
+    model = default_risk_model(assets=5, factors=2)
+    assert isinstance(model, FactorModel)
+    assert model.assets == 5
+    assert model.factors == 2
+
+
+def test_builder_defaults_through_this_function():
+    """A Builder with no injected risk model gets what this function returns."""
+    assert isinstance(MinVar(assets=5).risk, SampleCovariance)
+    assert isinstance(MinVar(assets=5, factors=2).risk, FactorModel)
+
+
+def test_an_injected_model_is_not_overwritten():
+    """Injecting a risk model skips the default entirely.
+
+    `CVar` needs `rows` and `alpha`, which a builder does not carry, so it can
+    never be a default -- injection is the only route, and this pins that it
+    survives `__post_init__`.
+    """
+    builder = MinVar(assets=5, model={M.RISK: CVar(assets=5, rows=50)})
+    assert isinstance(builder.risk, CVar)

--- a/tests/test_markowitz/test_risk/test_sample/test_sample.py
+++ b/tests/test_markowitz/test_risk/test_sample/test_sample.py
@@ -11,6 +11,19 @@ from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.risk import SampleCovariance
 
 
+def test_keywords_defaults_to_the_data_keys():
+    """A model that adds nothing to `data` inherits `keywords` from it.
+
+    The base-class half of the contract `ExpectedReturns` overrides: most
+    models consume exactly the keywords their `data` declares, so the default
+    implementation is what guards them in `Problem.update`.
+    """
+    riskmodel = SampleCovariance(assets=2)
+
+    assert set(riskmodel.keywords) == set(riskmodel.data)
+    assert set(riskmodel.keywords) == {D.CHOLESKY, D.VOLA_UNCERTAINTY}
+
+
 def test_sample():
     """Plain sample risk for 2 assets reproduces expected volatility."""
     riskmodel = SampleCovariance(assets=2)


### PR DESCRIPTION
## Summary

Addresses the four findings from the `/rhiza:quality` run. One is a real
behavioural defect where the package raised an exception outside its own error
tree; the other three are consistency, documentation and structure.

Closes #579
Closes #580
Closes #581
Closes #582

## Changes

**#579 — `Problem.update` let a bare `KeyError` escape the `CvxError` tree**

`Problem.update` built its missing-input check from `model.data` alone, but
`ExpectedReturns` keeps `mu_uncertainty` in `model.parameter`, so omitting it
fell through to `kwargs["mu_uncertainty"]` inside the model. That contradicted
the README's promise that a single `except CvxError` catches everything the
package raises.

- `Model` gains a `keywords` property — the keywords its `update` consumes,
  defaulting to the keys of `data`.
- `Problem.update` walks `model.keywords` instead of `model.data`.
- `ExpectedReturns` overrides it to declare `mu_uncertainty`.

It returns a tuple rather than a set so the key named in the error message
follows insertion order instead of set iteration order.

Verified with the same probe that surfaced it:

```
before:  NOT a CvxError -> KeyError KeyError('mu_uncertainty')
after:   CvxError: CvxDataError Missing data for mu_uncertainty in model return
```

**#580 — raw string literals bypassing `names.DataNames`**

Three `kwargs` reads used literals on lines adjacent to ones using the
constants (`factor.py:128`, `trading_costs.py:38/52/63`,
`expected_returns.py:72`). The risk is silent divergence rather than a typo:
presence checks iterate the constants, so a rename would update the validation
path but not the literal read one line later.

- Replaced all three; `grep` for `kwargs["`, `self.data["` and
  `self.parameter["` in `src/` now returns nothing.
- Added `ParameterName.POWER`, the one key that had no constant.
- Fixed the `update()` docstring that documented the keyword as `D.MU` — the
  Python name of the constant — where callers actually pass `mu`.

**#581 — no `CLAUDE.md`, thin packaging metadata**

- Adds `CLAUDE.md`: the template-owned vs. locally-owned split (68 synced
  paths per `.rhiza/template.lock`), the extension points that survive a sync
  (`Makefile`, `custom-task.mk`, `local.mk`), the commands, and the
  conventions a contributor cannot infer from the code — including that the
  `# Private :: Do Not Upload` comment is load-bearing, since
  `rhiza_release.yml` matches it with a plain `grep -R`.
- `pyproject.toml` gets a real `description` in place of `"Markowitz"`, and
  loses two commented-out lines dead since 2024.

**#582 — the abstract `Builder` named three concrete models**

Default risk-model selection moved into `cvxmarkowitz.risk` as
`default_risk_model`, so adding a default is a change to the risk subpackage
rather than to the base class every builder inherits from. `builder.py` no
longer imports `FactorModel` or `SampleCovariance`.

`Bounds` stays imported directly, with a comment saying why: it is
unconditional structure, not a choice among alternatives, so putting it behind
a selector would be indirection with nothing to select.

## Testing

- [x] `make test` passes locally — **83 passed**, up from 75
- [x] `make fmt` has been run
- [x] New tests added

The eight new tests cover the new code rather than relaxing the gate; coverage
stays at **100% of 455 statements**.

- `test_problem.py` — the specific `mu_uncertainty` regression, plus a general
  form that walks `Model.keywords` and drops each required keyword in turn, so
  a model that later consumes an undeclared keyword fails here rather than at a
  caller.
- `test_risk/test_defaults.py` — both branches of `default_risk_model`, that
  `Builder` routes through it, and that an injected `CVar` survives
  `__post_init__`.
- `test_expected_returns.py` / `test_sample.py` — the override and the
  base-class default of the `keywords` contract.

Full gate run: `fmt`, `typecheck` (`ty` + `mypy --strict`, 26 modules),
`docs-coverage` (292/292), `deps`, `security`, `rhiza-test` (40) and `test`
all pass, plus test-layout parity.

## Checklist

- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] `CHANGELOG.md` entry — not needed; the changelog is generated by
      git-cliff from commit messages
- [x] Documentation updated if behaviour changed
- [x] `make deps` passes (no unused or missing dependencies)

## One item deliberately not done

#581 also noted that `mock>=5.2.0` in the `dev` group is unused — nothing under
`tests/` imports it, and `pytest-mock` comes from `uv run --with` in
`python.mk:226`, not from the group. The edit removing it was declined during
review, so it is still there and `uv.lock` is untouched. Close #581 with a note
if that is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
