### PR TITLE
docs: describe Model as the component base, not a risk model

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ rho=0.9: objective=0.9958
 ## Errors
 
 Everything the package raises derives from `CvxError`, so a single
-`except CvxError` still catches all of it. Two subclasses separate the failure
-modes that want different handling:
+`except CvxError` still catches all of it. The subclasses below separate the
+failure modes that want different handling:
 
 | Error | Raised when | Retry helps? |
 |---|---|---|

--- a/src/cvxmarkowitz/model.py
+++ b/src/cvxmarkowitz/model.py
@@ -25,7 +25,22 @@ from cvxmarkowitz.types import Constraints, Matrix, Parameter, Variables
 
 @dataclass(frozen=True)
 class Model(ABC):
-    """Abstract risk model."""
+    """Abstract base for every component a `Builder` assembles.
+
+    Risk models are only part of it: `Bounds`, `ExpectedReturns`, `TradingCosts`
+    and `HoldingCosts` derive from this too. A component owns the cvxpy
+    Parameters it is built from and contributes an objective term (`estimate`),
+    constraints (`constraints`), or -- as `Bounds` does -- only the latter.
+
+    Attributes:
+        assets: Number of entries the component's parameters are sized for.
+        parameter: cvxpy Parameters the component holds that `data` does not
+            back. Some are set once at construction (`TradingCosts` fixes the
+            cost exponent this way); others are written by `update` from a
+            keyword, which is the case that requires overriding `keywords`.
+        data: cvxpy Parameters `update` fills from its keyword arguments, and
+            the default source of `keywords`.
+    """
 
     assets: int
     parameter: Parameter = field(default_factory=dict)
@@ -54,12 +69,24 @@ class Model(ABC):
 
     @abstractmethod
     def estimate(self, variables: Variables) -> cp.Expression:
-        """Estimate the variance given the portfolio weights."""
+        """Return this component's objective contribution, given the variables.
+
+        What the expression means is the component's own business: a risk model
+        returns a risk measure (`FactorModel` and `SampleCovariance` a norm, not
+        a variance; `CVar` a conditional value-at-risk), `ExpectedReturns` a
+        robust expected return, the cost models a cost. A component that
+        contributes no objective term at all raises `NotImplementedError` here
+        -- see `Bounds`, which is pure constraints.
+        """
 
     @abstractmethod
     def update(self, **kwargs: Matrix) -> None:
-        """Update the data in the risk model."""
+        """Write fresh values into this component's parameters, in place.
+
+        Each implementation documents the keywords it consumes; `keywords` is
+        what `Problem.update` checks those against before any value is written.
+        """
 
     def constraints(self, variables: Variables) -> Constraints:  # noqa: ARG002  # base default ignores `variables`; name kept to match overrides (LSP)
-        """Return the constraints for the risk model."""
+        """Return this component's named constraints; none by default."""
         return {}


### PR DESCRIPTION
Closes #584, closes #585. Both findings from the last `/rhiza:quality` run — documentation accuracy, which no gate measures.

## `Model` is not a risk model (#584)

`Model` is the ABC behind **eight** subclasses; only `FactorModel`, `SampleCovariance` and `CVar` are risk models. `Bounds`, `ExpectedReturns`, `TradingCosts` and `HoldingCosts` derive from it too. Four docstrings said otherwise, and `estimate`'s was wrong even for the risk models:

| | Old | Actual |
|---|---|---|
| `Model` | "Abstract risk model." | base for all eight components |
| `estimate` | "Estimate the variance…" | `FactorModel`/`SampleCovariance` return a norm, `CVar` a CVaR, `ExpectedReturns` a robust expected return, `Bounds` raises `NotImplementedError` |
| `update` | "…in the risk model." | in any component |
| `constraints` | "…for the risk model." | for any component |

interrogate reports 100% because it checks that a docstring exists, not that it is true. These four are the first thing anyone writing a custom component reads.

The class docstring now also documents the `parameter`/`data` split, since that is what decides whether a subclass must override `keywords` — the trap `CLAUDE.md` calls out and `ExpectedReturns` is the live instance of.

## README miscounted the error subclasses (#585)

`README.md:137` said "Two subclasses" directly above a table listing three — a leftover from before `CvxSolverError` joined the tree. Dropped the count instead of correcting it to three so it cannot drift again; the three-way split is already pinned by `test_public_api.py::test_every_exported_exception_derives_from_cvxerror`.

## Verification

Docs only, no behaviour change. `make fmt`, `make typecheck` (ty + mypy --strict), `make docs-coverage` (100%), `make rhiza-test` (40 passed) and `make test` (83 passed, 100.00% coverage) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)