### PR TITLE
docs: repair two stale cross-references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ because a change to a template-owned file is reverted by the next
 | `pyproject.toml` | manifest, tool config, dependency groups |
 | `README.md`, `mkdocs.yml` | project docs and site nav |
 | `.rhiza/template.yml` | which template ref this repo tracks |
-| `.clusterfuzzlite/`, `copyright.txt`, `portfolio.png` | local extras |
+| `copyright.txt`, `portfolio.png` | local extras |
 
 **Template-owned — fix upstream, not here:** `.github/**`, everything under
 `.rhiza/` except `template.yml`, all of `docs/`, plus `ruff.toml`, `pytest.ini`,

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ added.
 Every problem has to be constructed by a Builder. Here's a builder for a classic
 [minimum variance problem](src/cvxmarkowitz/portfolios/min_var.py).
 The builder inherits from the [Builder](src/cvxmarkowitz/builder.py)
-and implements the abstract property [objective](src/cvxmarkowitz/builder.py#L92).
+and implements the abstract property [objective](src/cvxmarkowitz/builder.py).
 The builder remains flexible. At this stage it is possible to add or remove
 constraints. Only once we trigger the build() method do we construct
 the problem and compile it.

--- a/tests/fuzz/fuzz_fill.py
+++ b/tests/fuzz/fuzz_fill.py
@@ -10,7 +10,11 @@ Run locally:
     pip install atheris numpy
     python tests/fuzz/fuzz_fill.py -atheris_runs=20000
 
-Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+CI fuzzing is off: the ClusterFuzzLite workflow is opt-in and needs both the
+`FUZZING_ENABLED` repository variable and a `.clusterfuzzlite/` config, and this
+repo currently has neither. Restoring that directory with a `build.sh` that
+compiles this harness is what turns the workflow back on; until then this file
+is a local-only harness.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes the documentation findings from a `/rhiza:quality` run (full mode, template v1.3.3).

## What was wrong

**`README.md:34`** linked the abstract `objective` property to `src/cvxmarkowitz/builder.py#L92`. That line is blank — the declaration is at `builder.py:110`. The anchor is dropped rather than renumbered, so a bare file link cannot go stale again the next time `builder.py` is edited.

**`.clusterfuzzlite/` was deleted in a5d5a8b**, but two locally-owned files still described it as present:

- `tests/fuzz/fuzz_fill.py:13` claimed `.clusterfuzzlite/build.sh` compiles the harness. Replaced with what is actually true: CI fuzzing is opt-in, needs both the `FUZZING_ENABLED` repository variable and a `.clusterfuzzlite/` config, and the repo has neither — so this is a local-only harness today. The note also says what restoring it would take.
- `CLAUDE.md:45` listed the directory under "local extras". Entry dropped; `copyright.txt` and `portfolio.png` both still exist and stay.

(`.github/workflows/rhiza_fuzzing.yml:12` mentions it too, but that file is template-owned and its reference is conditional — correct as written, left alone.)

Docs only. No source or test behaviour changes.

## Verification

- `make fmt` — 21/21 hooks pass, including markdownlint and both README hooks
- `make rhiza-test` — 40 passed (README validation, docstring and release-tag gates)
- `make test` — 83 passed, coverage 100.00% against the 100% gate

Closes #588

## Note on #589

The other finding from the same run — a stray `click` tag pointing at WIP commit `d8477ff` — has **already been fixed directly**, on both the local repo and the remote, since a tag deletion produces no file diff to carry in a PR. `git ls-remote --tags origin` now returns only `v0.0.1`. That issue is closed separately rather than by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)