### PR TITLE
fix: reject a CVaR tail size of zero at construction

### DIFF
--- a/src/cvxmarkowitz/risk/cvar/cvar.py
+++ b/src/cvxmarkowitz/risk/cvar/cvar.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import cvxpy as cp
 import numpy as np
 
+from cvxmarkowitz.cvxerror import CvxDataError
 from cvxmarkowitz.model import Model
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.types import Matrix, Variables
@@ -39,22 +40,38 @@ class CVar(Model):
         Creates the returns matrix parameter with shape `(rows, assets)` and
         zeros as default value. The `alpha` quantile controls tail size during
         estimation in `estimate`.
+
+        Raises:
+            CvxDataError: If `alpha` and `rows` leave fewer than one scenario in
+                the left tail. Checked here rather than in `estimate` because
+                both fields are frozen once construction returns, so the caller
+                is told at the point where the mistake can still be corrected.
         """
-        # self.k = int(self.n * (1 - self.alpha))
+        if self._tail_size < 1:
+            raise CvxDataError(  # noqa: TRY003
+                f"alpha={self.alpha} leaves no scenarios in the left tail of rows={self.rows}. "
+                f"Lower alpha or raise rows so that int(rows * (1 - alpha)) is at least 1."
+            )
+
         self.data[D.RETURNS] = cp.Parameter(
             shape=(self.rows, self.assets),
             name=D.RETURNS,
             value=np.zeros((self.rows, self.assets)),
         )
 
+    @property
+    def _tail_size(self) -> int:
+        """Return the number of scenarios averaged over the left tail."""
+        return int(self.rows * (1 - self.alpha))
+
     def estimate(self, variables: Variables) -> cp.Expression:
         """Estimate the risk by computing the Cholesky decomposition of self.cov."""
-        # R is a matrix of returns, n is the number of rows in R
-        # n = self.R.shape[0]
-        # k is the number of returns in the left tail
-        # k = int(n * (1 - self.alpha))
+        # R is a matrix of returns, n is the number of rows in R.
+        # k is the number of returns in the left tail; __post_init__ has already
+        # rejected any (alpha, rows) pair that would make it zero, which would
+        # otherwise reach cvxpy as a bare ValueError and divide by zero here.
+        k = self._tail_size
         # average value of the k elements in the left tail
-        k = int(self.rows * (1 - self.alpha))
         return -cp.sum_smallest(self.data[D.RETURNS] @ variables[D.WEIGHTS], k=k) / k
 
     def update(self, **kwargs: Matrix) -> None:

--- a/tests/test_markowitz/test_risk/test_cvar/test_cvar.py
+++ b/tests/test_markowitz/test_risk/test_cvar/test_cvar.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from cvxmarkowitz import CvxDataError
 from cvxmarkowitz.names import DataNames as D
 from cvxmarkowitz.names import ModelName as M
 from cvxmarkowitz.portfolios.min_var import MinVar
@@ -69,3 +70,37 @@ def test_default_risk_model_is_used_when_none_is_given():
     """Without an injected model the factors-based default still applies."""
     assert D.CHOLESKY in MinVar(assets=14).risk.data
     assert D.EXPOSURE in MinVar(assets=14, factors=3).risk.data
+
+
+@pytest.mark.parametrize(
+    ("alpha", "rows"),
+    [
+        (0.95, 10),  # int(10 * 0.05) == 0
+        (0.95, 0),  # the bare `rows` default
+        (1.0, 100),  # no tail at all
+    ],
+)
+def test_empty_tail_is_rejected_at_construction(alpha, rows):
+    """An (alpha, rows) pair leaving no left tail must raise CvxDataError.
+
+    Without the guard the zero tail size reaches cvxpy as a bare ValueError from
+    `sum_smallest`, which is outside the CvxError tree and names neither field.
+    """
+    with pytest.raises(CvxDataError, match="left tail"):
+        CVar(assets=4, alpha=alpha, rows=rows)
+
+
+def test_empty_tail_error_names_both_fields():
+    """The message must point at the two fields the caller can actually change."""
+    with pytest.raises(CvxDataError) as excinfo:
+        CVar(assets=4, alpha=0.95, rows=10)
+
+    assert "alpha=0.95" in str(excinfo.value)
+    assert "rows=10" in str(excinfo.value)
+
+
+def test_smallest_admissible_tail_is_accepted():
+    """A single scenario in the tail is enough; the guard must not over-reject."""
+    model = CVar(assets=4, alpha=0.95, rows=20)  # int(20 * 0.05) == 1
+
+    assert D.RETURNS in model.data


### PR DESCRIPTION
Closes #591, the one finding from the `/rhiza:quality` run.

## The problem

`CVar.estimate` computed the left-tail size as `int(rows * (1 - alpha))` and never
checked the result. A plausible pair yields zero:

```console
$ python -c "
from cvxmarkowitz.risk.cvar.cvar import CVar
import cvxpy as cp
CVar(assets=4, rows=10, alpha=0.95).estimate({'weights': cp.Variable(4, name='weights')})
"
ValueError: Second argument must be a positive number.
```

`cp.sum_smallest(..., k=0)` raises before the `/ k` division is reached, so the
caller sees a cvxpy internal that is outside the `CvxError` tree the README
documents as the contract — and that names neither `alpha` nor `rows`, the two
fields they could actually change.

The path is reachable through the documented API: `builder.py:79` names direct
`CVar` injection as the supported route to a non-default risk model.

## The fix

Validate in `__post_init__` rather than in `estimate`. Both `alpha` and `rows` are
frozen once construction returns, so failing there reports the mistake at the point
where it can still be corrected, rather than partway through assembling an
objective. The error is a `CvxDataError` naming both fields and the fix:

```
alpha=0.95 leaves no scenarios in the left tail of rows=10.
Lower alpha or raise rows so that int(rows * (1 - alpha)) is at least 1.
```

The tail-size expression, previously duplicated between the guard and `estimate`,
moves behind a `_tail_size` property — which also retires the commented-out
`# self.k = int(self.n * (1 - self.alpha))` line that had anticipated exactly this.

## Behaviour change

`CVar()` with the bare `rows=0` default now raises at construction instead of at
estimate time. Nothing constructs one: every call site in `src/`, `tests/` and the
docstrings passes an explicit `rows` of 50 or 100. A CVaR model over zero scenarios
has no meaning, so this is the degenerate case the guard is for.

## Tests

Five new cases in `test_cvar.py`: three parametrized empty-tail configurations
(`rows` too small, the bare default, `alpha=1.0`), one asserting the message names
both fields, and one pinning `rows=20, alpha=0.95` — a tail of exactly one — so the
guard cannot drift into over-rejecting.

## Gates

All seven pass on this branch: `fmt`, `typecheck` (`ty` + `mypy --strict`),
`docs-coverage` (100%), `deps`, `security`, `rhiza-test` (40 passed), and `test` —
88 passed with coverage holding at 100.00% of 461 statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
