### PR TITLE
chore: update rhiza to v1.5.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,9 +1,10 @@
-sha: 8ef5b50907aaf9c29aaf24c8c8de34a015f486a6
+sha: de568b1e79e5871c58b4349762ce9dfd31d73e99
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.0
+ref: v1.5.1
 include: []
-exclude: []
+exclude:
+- .github/workflows/rhiza_mutation.yml
 templates:
 - legal
 profiles:
@@ -43,5 +44,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-22T11:30:01Z'
+synced_at: '2026-08-22T18:21:47Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.0"
+ref: "v1.5.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Rhiza template update

`jebel-quant/rhiza`: **v1.5.0 → v1.5.1**

- 34 template files considered, **8 changed**: 7 `rhiza_*.yml` reusable-workflow pins bumped to `@v1.5.1`, plus `.rhiza/template.lock`.
- **No conflicts** — the sync completed clean (exit 0).
- Nothing was left unstaged; this branch contains template-owned files only.

**No gates were run.** Run `/rhiza:quality` for a scorecard, `/rhiza:status` to see what is now synced.
