### PR TITLE
chore: update rhiza to v1.6.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.6.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.6.0
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.6.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.6.0
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
         groups: ["lint", "fast"]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: 0.26
+    rev: "0.26"
     hooks:
       - id: validate-pyproject
         groups: ["python", "fast"]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -3,7 +3,8 @@ repo: jebel-quant/rhiza
 host: github
 ref: v1.6.0
 include: []
-exclude: []
+exclude:
+- SECURITY.md
 templates:
 - legal
 profiles:
@@ -33,7 +34,6 @@ files:
 - .rhiza/semgrep.yml
 - LICENSE
 - Makefile
-- SECURITY.md
 - cliff.toml
 - docs/assets/rhiza-logo.svg
 - docs/development/MARIMO.md
@@ -43,5 +43,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-25T07:12:41Z'
+synced_at: '2026-08-25T07:27:02Z'
 strategy: merge

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,10 +1,9 @@
-sha: de568b1e79e5871c58b4349762ce9dfd31d73e99
+sha: e556617285b215566e563c58022c3a031e870aad
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.1
+ref: v1.6.0
 include: []
-exclude:
-- .github/workflows/rhiza_mutation.yml
+exclude: []
 templates:
 - legal
 profiles:
@@ -44,5 +43,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-22T18:21:47Z'
+synced_at: '2026-08-25T07:12:41Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.1"
+ref: "v1.6.0"
 
 profiles:
   - github-project

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -7,3 +7,13 @@ profiles:
 templates:
   - legal
 
+# Template-owned paths this repo declines to sync. Matched against *destination*
+# paths — where the file lands here — so entries are written as `.github/...`,
+# never clone-relative (`bundles/...`), which matches nothing silently.
+exclude:
+  # SECURITY.md. The template's copy enumerates security measures generically;
+  # the accurate list differs per repo, so this one is maintained here. Excluding
+  # it does not delete the file — an excluded path is never treated as an orphan,
+  # so the existing SECURITY.md stays exactly as it is and simply stops being
+  # overwritten on each sync.
+  - SECURITY.md

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.1.0
+RHIZA_TASK ?= rhiza-task@1.3.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/cliff.toml
+++ b/cliff.toml
@@ -64,8 +64,19 @@ sort_commits = "oldest"
 # Group commits into changelog sections. The leading HTML comment controls the
 # section ordering and is stripped from the rendered heading via `striptags`.
 commit_parsers = [
-  # Drop automated noise commits that don't provide user-facing signal.
-  { message = ".*\\[skip ci\\].*", skip = true },
+  # Drop automated noise commits that don't provide user-facing signal -- the machine-written
+  # `Update the compiled paper [skip ci]` kind, which puts the marker in its *subject*.
+  #
+  # Anchored to the subject line, and that is load-bearing rather than tidy. git-cliff matches
+  # this against the whole message, so the unanchored `.*\[skip ci\].*` also dropped any commit
+  # whose *body* merely mentioned the marker -- a commit message quoting the format of another
+  # commit message is enough. That silently ate `feat: give the paper branch a README` (#1626)
+  # out of v1.6.0's notes, for one backticked mention twenty lines down. Same failure as the
+  # `bump` alternative below: a substring search treating a mention as the thing itself.
+  #
+  # `^` with no `(?m)` is start-of-message, and `[^\n]*` cannot cross a newline, so only the
+  # subject can match.
+  { message = "^[^\\n]*\\[skip ci\\]", skip = true },
   # Only the release flow's own commits. A bare `bump` alternative here also ate every
   # `chore(deps): bump <dependency>` — the rhiza-hooks v1.2.0 bump (#1487) vanished from
   # v1.3.2's notes that way, and had been vanishing for a while unnoticed: a Dependabot


### PR DESCRIPTION
Template `jebel-quant/rhiza`: `v1.5.1` → **`v1.6.0`**.

- 34 template files considered, **11 changed** (7 workflow callers, `.pre-commit-config.yaml`, `Makefile`, `cliff.toml`, `.rhiza/template.lock`).
- No conflicts — nothing had to be resolved.
- Nothing left unstaged: the sync touched no repo-owned files.

No gates were run — run `/rhiza:quality` for a scorecard.

---

### Also in this PR: `SECURITY.md` is no longer template-owned

`SECURITY.md` moved from the lock's `files:` list into `exclude:`. The template's
copy enumerates security measures generically and the accurate list differs per
repo, so it is maintained here from now on.

Excluding a path does **not** delete it — `clean_orphaned_files` skips excluded
paths ("an excluded path is never an orphan"), and the file is byte-identical
before and after the re-sync. It simply stops being overwritten on each sync.
