### PR TITLE
chore: update rhiza to v1.7.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.1
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.1
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 77f8315ef3ce0a921862b6ea84ef3e316610c619
+sha: da1e30177bebbd6fea9983bb36f5eef311e40235
 repo: jebel-quant/rhiza
 host: github
-ref: v1.7.0
+ref: v1.7.1
 include: []
 exclude:
 - SECURITY.md
@@ -41,5 +41,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-26T16:36:23Z'
+synced_at: '2026-08-28T18:34:21Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.7.0"
+ref: "v1.7.1"
 
 profiles:
   - github-project

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.4.0
+RHIZA_TASK ?= rhiza-task@1.4.1
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -72,6 +72,9 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
 
+  logo: https://jebel-quant.github.io/rhiza/assets/rhiza-logo.svg
+  favicon: https://jebel-quant.github.io/rhiza/assets/rhiza-logo.svg
+  
 # ----------------------------------------------------------------------------
 # Markdown extensions
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Bumps the rhiza template pointer and re-applies the sync.

- **Template:** `jebel-quant/rhiza`
- **Ref:** `v1.7.0` → `v1.7.1`
- **Files changed by the sync:** 10 (7 reusable-workflow pins, `.rhiza/template.lock`, `Makefile`, `docs/mkdocs-base.yml`)
- **Conflicts:** none — the sync merged cleanly.
- **Left unstaged:** nothing; the working tree is clean apart from the staged template-owned files.

Notable content: the workflow `uses:` pins move to `@v1.7.1`, `RHIZA_TASK` moves to `rhiza-task@1.4.1`, and `docs/mkdocs-base.yml` gains the rhiza logo/favicon.

> No gates were run — `/update` syncs, it does not score. Run `/rhiza:quality` for a scorecard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
