### PR TITLE
chore: declare Python 3.13 and 3.14 classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Adds `Programming Language :: Python :: 3.13` and `:: 3.14` to the trove
classifiers in `pyproject.toml`. `requires-python` is already `>=3.11`, so both
versions were supported but undeclared.

## Notes

The working-tree change also carried a stray leading apostrophe on the
`[project]` table header (`'[project]`), which made the file invalid TOML. That
was corrected before committing — the diff here is classifiers only.

## Testing

- `make fmt` — full pre-commit suite passes (including `check toml`, `Validate pyproject.toml`, `Check Python version consistency`)
- `make test` — 88 passed, 100% coverage gate met

🤖 Generated with [Claude Code](https://claude.com/claude-code)